### PR TITLE
Add clearTxn Command, data and utility classes for transaction tests

### DIFF
--- a/src/main/java/spleetwaise/address/logic/Logic.java
+++ b/src/main/java/spleetwaise/address/logic/Logic.java
@@ -10,6 +10,7 @@ import spleetwaise.address.logic.parser.exceptions.ParseException;
 import spleetwaise.address.model.Model;
 import spleetwaise.address.model.ReadOnlyAddressBook;
 import spleetwaise.address.model.person.Person;
+import spleetwaise.commons.exceptions.SpleetWaiseCommandException;
 
 /**
  * API of the Logic component
@@ -22,7 +23,7 @@ public interface Logic {
      * @throws CommandException If an error occurs during command execution.
      * @throws ParseException If an error occurs during parsing.
      */
-    CommandResult execute(String commandText) throws CommandException, ParseException;
+    CommandResult execute(String commandText) throws SpleetWaiseCommandException, ParseException;
 
     /**
      * Returns the AddressBook.

--- a/src/main/java/spleetwaise/address/logic/LogicManager.java
+++ b/src/main/java/spleetwaise/address/logic/LogicManager.java
@@ -17,6 +17,7 @@ import spleetwaise.address.logic.parser.exceptions.ParseException;
 import spleetwaise.address.model.ReadOnlyAddressBook;
 import spleetwaise.address.model.person.Person;
 import spleetwaise.address.storage.Storage;
+import spleetwaise.commons.exceptions.SpleetWaiseCommandException;
 import spleetwaise.transaction.logic.parser.ParserUtil;
 import spleetwaise.transaction.logic.parser.TransactionParser;
 
@@ -42,7 +43,7 @@ public class LogicManager implements Logic {
      * Constructs a {@code LogicManager} with the given {@code Model} and {@code Storage}.
      */
     public LogicManager(spleetwaise.address.model.Model addressBookModel,
-        spleetwaise.transaction.model.Model transactionModel, Storage storage) {
+                        spleetwaise.transaction.model.Model transactionModel, Storage storage) {
         this.addressBookModel = addressBookModel;
         this.transactionModel = transactionModel;
         this.storage = storage;
@@ -52,7 +53,7 @@ public class LogicManager implements Logic {
     }
 
     @Override
-    public CommandResult execute(String commandText) throws CommandException, ParseException {
+    public CommandResult execute(String commandText) throws ParseException, SpleetWaiseCommandException {
         logger.info("----------------[USER COMMAND][" + commandText + "]");
 
         CommandResult commandResult;
@@ -67,31 +68,6 @@ public class LogicManager implements Logic {
         }
 
         throw new ParseException(String.format(MESSAGE_UNKNOWN_COMMAND, commandText));
-    }
-
-    private CommandResult executeAddressBookCommand(spleetwaise.address.logic.commands.Command addressBookCommand)
-            throws CommandException {
-        CommandResult commandResult = addressBookCommand.execute(addressBookModel);
-
-        // Save AddressBook data
-        try {
-            storage.saveAddressBook(addressBookModel.getAddressBook());
-        } catch (AccessDeniedException e) {
-            throw new CommandException(String.format(FILE_OPS_PERMISSION_ERROR_FORMAT, e.getMessage()), e);
-        } catch (IOException ioe) {
-            throw new CommandException(String.format(FILE_OPS_ERROR_FORMAT, ioe.getMessage()), ioe);
-        }
-
-        return commandResult;
-    }
-
-    private CommandResult executeTransactionCommand(spleetwaise.transaction.logic.commands.Command transactionCommand)
-            throws CommandException {
-        CommandResult commandResult = transactionCommand.execute(transactionModel);
-
-        // TODO: Save Transactions data
-
-        return commandResult;
     }
 
     @Override
@@ -117,5 +93,30 @@ public class LogicManager implements Logic {
     @Override
     public void setGuiSettings(GuiSettings guiSettings) {
         addressBookModel.setGuiSettings(guiSettings);
+    }
+
+    private CommandResult executeAddressBookCommand(spleetwaise.address.logic.commands.Command addressBookCommand)
+            throws SpleetWaiseCommandException {
+        CommandResult commandResult = addressBookCommand.execute(addressBookModel);
+
+        // Save AddressBook data
+        try {
+            storage.saveAddressBook(addressBookModel.getAddressBook());
+        } catch (AccessDeniedException e) {
+            throw new CommandException(String.format(FILE_OPS_PERMISSION_ERROR_FORMAT, e.getMessage()), e);
+        } catch (IOException ioe) {
+            throw new CommandException(String.format(FILE_OPS_ERROR_FORMAT, ioe.getMessage()), ioe);
+        }
+
+        return commandResult;
+    }
+
+    private CommandResult executeTransactionCommand(spleetwaise.transaction.logic.commands.Command transactionCommand)
+            throws SpleetWaiseCommandException {
+        CommandResult commandResult = transactionCommand.execute(transactionModel);
+
+        // TODO: Save Transactions data
+
+        return commandResult;
     }
 }

--- a/src/main/java/spleetwaise/address/logic/commands/exceptions/CommandException.java
+++ b/src/main/java/spleetwaise/address/logic/commands/exceptions/CommandException.java
@@ -1,16 +1,15 @@
 package spleetwaise.address.logic.commands.exceptions;
 
+import spleetwaise.commons.exceptions.SpleetWaiseCommandException;
+
 /**
- * Represents an error which occurs during execution of a {@link Command}.
+ * Represents an error that occurs during command execution in the address component.
  */
-public class CommandException extends Exception {
+public class CommandException extends SpleetWaiseCommandException {
     public CommandException(String message) {
         super(message);
     }
 
-    /**
-     * Constructs a new {@code CommandException} with the specified detail {@code message} and {@code cause}.
-     */
     public CommandException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/src/main/java/spleetwaise/address/ui/CommandBox.java
+++ b/src/main/java/spleetwaise/address/ui/CommandBox.java
@@ -6,8 +6,8 @@ import javafx.scene.control.TextField;
 import javafx.scene.layout.Region;
 import spleetwaise.address.logic.Logic;
 import spleetwaise.address.logic.commands.CommandResult;
-import spleetwaise.address.logic.commands.exceptions.CommandException;
 import spleetwaise.address.logic.parser.exceptions.ParseException;
+import spleetwaise.commons.exceptions.SpleetWaiseCommandException;
 
 /**
  * The UI component that is responsible for receiving user command inputs.
@@ -19,8 +19,7 @@ public class CommandBox extends UiPart<Region> {
 
     private final CommandExecutor commandExecutor;
 
-    @FXML
-    private TextField commandTextField;
+    @FXML private TextField commandTextField;
 
     /**
      * Creates a {@code CommandBox} with the given {@code CommandExecutor}.
@@ -36,7 +35,7 @@ public class CommandBox extends UiPart<Region> {
      * Handles the Enter button pressed event.
      */
     @FXML
-    private void handleCommandEntered() {
+    private void handleCommandEntered() throws SpleetWaiseCommandException, ParseException {
         String commandText = commandTextField.getText();
         if (commandText.equals("")) {
             return;
@@ -45,7 +44,7 @@ public class CommandBox extends UiPart<Region> {
         try {
             commandExecutor.execute(commandText);
             commandTextField.setText("");
-        } catch (CommandException | ParseException e) {
+        } catch (SpleetWaiseCommandException | ParseException e) {
             setStyleToIndicateCommandFailure();
         }
     }
@@ -80,7 +79,7 @@ public class CommandBox extends UiPart<Region> {
          *
          * @see Logic#execute(String)
          */
-        CommandResult execute(String commandText) throws CommandException, ParseException;
+        CommandResult execute(String commandText) throws SpleetWaiseCommandException, ParseException;
     }
 
 }

--- a/src/main/java/spleetwaise/address/ui/MainWindow.java
+++ b/src/main/java/spleetwaise/address/ui/MainWindow.java
@@ -14,8 +14,8 @@ import spleetwaise.address.commons.core.GuiSettings;
 import spleetwaise.address.commons.core.LogsCenter;
 import spleetwaise.address.logic.Logic;
 import spleetwaise.address.logic.commands.CommandResult;
-import spleetwaise.address.logic.commands.exceptions.CommandException;
 import spleetwaise.address.logic.parser.exceptions.ParseException;
+import spleetwaise.commons.exceptions.SpleetWaiseCommandException;
 
 /**
  * The Main Window. Provides the basic application layout containing
@@ -27,28 +27,21 @@ public class MainWindow extends UiPart<Stage> {
 
     private final Logger logger = LogsCenter.getLogger(getClass());
 
-    private Stage primaryStage;
-    private Logic logic;
-
+    private final Stage primaryStage;
+    private final Logic logic;
+    private final HelpWindow helpWindow;
     // Independent Ui parts residing in this Ui container
     private PersonListPanel personListPanel;
     private ResultDisplay resultDisplay;
-    private HelpWindow helpWindow;
+    @FXML private StackPane commandBoxPlaceholder;
 
-    @FXML
-    private StackPane commandBoxPlaceholder;
+    @FXML private MenuItem helpMenuItem;
 
-    @FXML
-    private MenuItem helpMenuItem;
+    @FXML private StackPane personListPanelPlaceholder;
 
-    @FXML
-    private StackPane personListPanelPlaceholder;
+    @FXML private StackPane resultDisplayPlaceholder;
 
-    @FXML
-    private StackPane resultDisplayPlaceholder;
-
-    @FXML
-    private StackPane statusbarPlaceholder;
+    @FXML private StackPane statusbarPlaceholder;
 
     /**
      * Creates a {@code MainWindow} with the given {@code Stage} and {@code Logic}.
@@ -78,6 +71,7 @@ public class MainWindow extends UiPart<Stage> {
 
     /**
      * Sets the accelerator of a MenuItem.
+     *
      * @param keyCombination the KeyCombination value of the accelerator
      */
     private void setAccelerator(MenuItem menuItem, KeyCombination keyCombination) {
@@ -156,8 +150,9 @@ public class MainWindow extends UiPart<Stage> {
      */
     @FXML
     private void handleExit() {
-        GuiSettings guiSettings = new GuiSettings(primaryStage.getWidth(), primaryStage.getHeight(),
-                (int) primaryStage.getX(), (int) primaryStage.getY());
+        GuiSettings guiSettings =
+            new GuiSettings(primaryStage.getWidth(), primaryStage.getHeight(), (int) primaryStage.getX(),
+                (int) primaryStage.getY());
         logic.setGuiSettings(guiSettings);
         helpWindow.hide();
         primaryStage.hide();
@@ -172,7 +167,7 @@ public class MainWindow extends UiPart<Stage> {
      *
      * @see Logic#execute(String)
      */
-    private CommandResult executeCommand(String commandText) throws CommandException, ParseException {
+    private CommandResult executeCommand(String commandText) throws SpleetWaiseCommandException, ParseException {
         try {
             CommandResult commandResult = logic.execute(commandText);
             logger.info("Result: " + commandResult.getFeedbackToUser());
@@ -187,7 +182,7 @@ public class MainWindow extends UiPart<Stage> {
             }
 
             return commandResult;
-        } catch (CommandException | ParseException e) {
+        } catch (SpleetWaiseCommandException | ParseException e) {
             logger.info("An error occurred while executing command: " + commandText);
             resultDisplay.setFeedbackToUser(e.getMessage());
             throw e;

--- a/src/main/java/spleetwaise/commons/exceptions/SpleetWaiseCommandException.java
+++ b/src/main/java/spleetwaise/commons/exceptions/SpleetWaiseCommandException.java
@@ -1,0 +1,14 @@
+package spleetwaise.commons.exceptions;
+
+/**
+ * Represents an exception that occurs during command execution in SpleetWaise.
+ */
+public class SpleetWaiseCommandException extends Exception {
+    public SpleetWaiseCommandException(String message) {
+        super(message);
+    }
+
+    public SpleetWaiseCommandException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/spleetwaise/transaction/logic/commands/AddCommand.java
+++ b/src/main/java/spleetwaise/transaction/logic/commands/AddCommand.java
@@ -8,7 +8,7 @@ import static spleetwaise.transaction.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 
 import spleetwaise.address.commons.util.ToStringBuilder;
 import spleetwaise.address.logic.commands.CommandResult;
-import spleetwaise.address.logic.commands.exceptions.CommandException;
+import spleetwaise.transaction.logic.commands.exceptions.CommandException;
 import spleetwaise.transaction.model.Model;
 import spleetwaise.transaction.model.transaction.Transaction;
 
@@ -32,17 +32,11 @@ public class AddCommand extends Command {
     /**
      * The message usage string that explains how to use this command.
      */
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Add a new transaction.\n"
-            + "Parameters: "
-            + PREFIX_PHONE + "CONTACT "
-            + PREFIX_AMOUNT + "AMOUNT "
-            + PREFIX_DESCRIPTION + "DESCRIPTION "
-            + "[" + PREFIX_DATE + "DATE ]\n"
-            + "Example: " + COMMAND_WORD + " "
-            + PREFIX_PHONE + "88888888 "
-            + PREFIX_AMOUNT + "10.00 "
-            + PREFIX_DESCRIPTION + "Paid John for lunch"
-            + PREFIX_DATE + "23012024 ";
+    public static final String MESSAGE_USAGE =
+        COMMAND_WORD + ": Add a new transaction.\n" + "Parameters: " + PREFIX_PHONE + "CONTACT " + PREFIX_AMOUNT
+            + "AMOUNT " + PREFIX_DESCRIPTION + "DESCRIPTION " + "[" + PREFIX_DATE + "DATE ]\n" + "Example: "
+            + COMMAND_WORD + " " + PREFIX_PHONE + "88888888 " + PREFIX_AMOUNT + "10.00 " + PREFIX_DESCRIPTION
+            + "Paid John for lunch" + PREFIX_DATE + "23012024 ";
 
 
     private final Transaction transactionToAdd;
@@ -81,19 +75,16 @@ public class AddCommand extends Command {
             return true;
         }
 
-        if (!(other instanceof AddCommand)) {
+        if (!(other instanceof AddCommand otherAddCommand)) {
             return false;
         }
 
-        AddCommand otherAddCommand = (AddCommand) other;
         return transactionToAdd.equals(otherAddCommand.transactionToAdd);
     }
 
     @Override
     public String toString() {
-        return new ToStringBuilder(this)
-                .add("txnToAdd", transactionToAdd)
-                .toString();
+        return new ToStringBuilder(this).add("txnToAdd", transactionToAdd).toString();
     }
 
 }

--- a/src/main/java/spleetwaise/transaction/logic/commands/ClearCommand.java
+++ b/src/main/java/spleetwaise/transaction/logic/commands/ClearCommand.java
@@ -1,0 +1,21 @@
+package spleetwaise.transaction.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import spleetwaise.address.logic.commands.CommandResult;
+import spleetwaise.transaction.model.Model;
+import spleetwaise.transaction.model.TransactionBook;
+
+public class ClearCommand extends Command {
+
+    public static final String COMMAND_WORD = "clearTxn";
+    public static final String MESSAGE_SUCCESS = "Transaction book has been cleared!";
+
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.setTransactionBook(new TransactionBook());
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+}

--- a/src/main/java/spleetwaise/transaction/logic/commands/ClearCommand.java
+++ b/src/main/java/spleetwaise/transaction/logic/commands/ClearCommand.java
@@ -6,6 +6,9 @@ import spleetwaise.address.logic.commands.CommandResult;
 import spleetwaise.transaction.model.Model;
 import spleetwaise.transaction.model.TransactionBook;
 
+/**
+ * Represents a command to clear the transaction book.
+ */
 public class ClearCommand extends Command {
 
     public static final String COMMAND_WORD = "clearTxn";

--- a/src/main/java/spleetwaise/transaction/logic/commands/Command.java
+++ b/src/main/java/spleetwaise/transaction/logic/commands/Command.java
@@ -1,7 +1,7 @@
 package spleetwaise.transaction.logic.commands;
 
 import spleetwaise.address.logic.commands.CommandResult;
-import spleetwaise.address.logic.commands.exceptions.CommandException;
+import spleetwaise.transaction.logic.commands.exceptions.CommandException;
 import spleetwaise.transaction.model.Model;
 
 /**

--- a/src/main/java/spleetwaise/transaction/logic/commands/exceptions/CommandException.java
+++ b/src/main/java/spleetwaise/transaction/logic/commands/exceptions/CommandException.java
@@ -1,0 +1,17 @@
+package spleetwaise.transaction.logic.commands.exceptions;
+
+/**
+ * Represents an error which occurs during execution of a {@link Command}.
+ */
+public class CommandException extends Exception {
+    public CommandException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new {@code CommandException} with the specified detail {@code message} and {@code cause}.
+     */
+    public CommandException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/spleetwaise/transaction/logic/commands/exceptions/CommandException.java
+++ b/src/main/java/spleetwaise/transaction/logic/commands/exceptions/CommandException.java
@@ -1,16 +1,15 @@
 package spleetwaise.transaction.logic.commands.exceptions;
 
+import spleetwaise.commons.exceptions.SpleetWaiseCommandException;
+
 /**
- * Represents an error which occurs during execution of a {@link Command}.
+ * Represents an error that occurs during command execution in the transaction component.
  */
-public class CommandException extends Exception {
+public class CommandException extends SpleetWaiseCommandException {
     public CommandException(String message) {
         super(message);
     }
 
-    /**
-     * Constructs a new {@code CommandException} with the specified detail {@code message} and {@code cause}.
-     */
     public CommandException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/src/test/java/spleetwaise/address/logic/LogicManagerTest.java
+++ b/src/test/java/spleetwaise/address/logic/LogicManagerTest.java
@@ -26,6 +26,7 @@ import spleetwaise.address.storage.StorageManager;
 import spleetwaise.address.testutil.Assert;
 import spleetwaise.address.testutil.PersonBuilder;
 import spleetwaise.address.testutil.TypicalPersons;
+import spleetwaise.commons.exceptions.SpleetWaiseCommandException;
 import spleetwaise.transaction.logic.parser.ParserUtil;
 import spleetwaise.transaction.model.transaction.TransactionIdUtil;
 
@@ -36,7 +37,6 @@ public class LogicManagerTest {
 
     @TempDir
     public Path temporaryFolder;
-
     private spleetwaise.address.model.Model addressBookModel = new spleetwaise.address.model.ModelManager();
     private spleetwaise.transaction.model.Model transactionModel = new spleetwaise.transaction.model.ModelManager();
     private Logic logic;
@@ -44,7 +44,7 @@ public class LogicManagerTest {
     @BeforeEach
     public void setUp() {
         JsonAddressBookStorage addressBookStorage =
-            new JsonAddressBookStorage(temporaryFolder.resolve("addressBook.json"));
+                new JsonAddressBookStorage(temporaryFolder.resolve("addressBook.json"));
         JsonUserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(temporaryFolder.resolve("userPrefs.json"));
         StorageManager storage = new StorageManager(addressBookStorage, userPrefsStorage);
         logic = new LogicManager(addressBookModel, transactionModel, storage);
@@ -105,14 +105,16 @@ public class LogicManagerTest {
 
     @Test
     public void execute_storageThrowsIoException_throwsCommandException() {
-        assertCommandFailureForExceptionFromStorage(DUMMY_IO_EXCEPTION, String.format(
-            LogicManager.FILE_OPS_ERROR_FORMAT, DUMMY_IO_EXCEPTION.getMessage()));
+        assertCommandFailureForExceptionFromStorage(DUMMY_IO_EXCEPTION,
+                String.format(LogicManager.FILE_OPS_ERROR_FORMAT,
+                        DUMMY_IO_EXCEPTION.getMessage()));
     }
 
     @Test
     public void execute_storageThrowsAdException_throwsCommandException() {
-        assertCommandFailureForExceptionFromStorage(DUMMY_AD_EXCEPTION, String.format(
-            LogicManager.FILE_OPS_PERMISSION_ERROR_FORMAT, DUMMY_AD_EXCEPTION.getMessage()));
+        assertCommandFailureForExceptionFromStorage(DUMMY_AD_EXCEPTION,
+                String.format(LogicManager.FILE_OPS_PERMISSION_ERROR_FORMAT,
+                        DUMMY_AD_EXCEPTION.getMessage()));
     }
 
     @Test
@@ -129,8 +131,9 @@ public class LogicManagerTest {
      * spleetwaise.transaction.model.Model)
      */
     private void assertCommandSuccess(String inputCommand, String expectedMessage,
-        spleetwaise.address.model.Model expectedAddressBookModel,
-        spleetwaise.transaction.model.Model expectedTransactionModel) throws CommandException, ParseException {
+                                      spleetwaise.address.model.Model expectedAddressBookModel,
+                                      spleetwaise.transaction.model.Model expectedTransactionModel)
+            throws SpleetWaiseCommandException, ParseException {
         CommandResult result = logic.execute(inputCommand);
         assertEquals(expectedMessage, result.getFeedbackToUser());
         assertEquals(expectedAddressBookModel, addressBookModel);
@@ -164,13 +167,13 @@ public class LogicManagerTest {
      * spleetwaise.transaction.model.Model)
      */
     private void assertCommandFailure(String inputCommand, Class<? extends Throwable> expectedException,
-        String expectedMessage) {
+                                      String expectedMessage) {
         spleetwaise.address.model.Model expectedAddressBookModel =
-            new spleetwaise.address.model.ModelManager(addressBookModel.getAddressBook(), new UserPrefs());
+                new spleetwaise.address.model.ModelManager(addressBookModel.getAddressBook(), new UserPrefs());
 
         spleetwaise.transaction.model.Model expectedTransactionModel = new spleetwaise.transaction.model.ModelManager();
         assertCommandFailure(inputCommand, expectedException, expectedMessage, expectedAddressBookModel,
-            expectedTransactionModel);
+                expectedTransactionModel);
     }
 
     /**
@@ -181,9 +184,8 @@ public class LogicManagerTest {
      * @see #assertCommandSuccess(String, String, spleetwaise.address.model.Model, spleetwaise.transaction.model.Model)
      */
     private void assertCommandFailure(String inputCommand, Class<? extends Throwable> expectedException,
-        String expectedMessage,
-        spleetwaise.address.model.Model expectedAddressBookModel,
-        spleetwaise.transaction.model.Model expectedTransactionModel) {
+                                      String expectedMessage, spleetwaise.address.model.Model expectedAddressBookModel,
+                                      spleetwaise.transaction.model.Model expectedTransactionModel) {
         Assert.assertThrows(expectedException, expectedMessage, () -> logic.execute(inputCommand));
         assertEquals(expectedAddressBookModel, addressBookModel);
         assertEquals(expectedTransactionModel, transactionModel);
@@ -207,23 +209,22 @@ public class LogicManagerTest {
         };
 
         JsonUserPrefsStorage userPrefsStorage =
-            new JsonUserPrefsStorage(temporaryFolder.resolve("ExceptionUserPrefs.json"));
+                new JsonUserPrefsStorage(temporaryFolder.resolve("ExceptionUserPrefs.json"));
         StorageManager storage = new StorageManager(addressBookStorage, userPrefsStorage);
 
         logic = new LogicManager(addressBookModel, transactionModel, storage);
 
         // Triggers the saveAddressBook method by executing an add command
         String addCommand = AddCommand.COMMAND_WORD + CommandTestUtil.NAME_DESC_AMY + CommandTestUtil.PHONE_DESC_AMY
-            + CommandTestUtil.EMAIL_DESC_AMY + CommandTestUtil.ADDRESS_DESC_AMY;
+                + CommandTestUtil.EMAIL_DESC_AMY + CommandTestUtil.ADDRESS_DESC_AMY;
         Person expectedPerson = new PersonBuilder(TypicalPersons.AMY).withTags().build();
 
         spleetwaise.address.model.Model expectedAddressBookModel = new spleetwaise.address.model.ModelManager();
         expectedAddressBookModel.addPerson(expectedPerson);
 
-        spleetwaise.transaction.model.Model expectedTransactionModel =
-            new spleetwaise.transaction.model.ModelManager();
+        spleetwaise.transaction.model.Model expectedTransactionModel = new spleetwaise.transaction.model.ModelManager();
 
         assertCommandFailure(addCommand, CommandException.class, expectedMessage, expectedAddressBookModel,
-            expectedTransactionModel);
+                expectedTransactionModel);
     }
 }

--- a/src/test/java/spleetwaise/transaction/logic/commands/AddCommandTest.java
+++ b/src/test/java/spleetwaise/transaction/logic/commands/AddCommandTest.java
@@ -2,17 +2,17 @@ package spleetwaise.transaction.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
 import spleetwaise.address.logic.commands.CommandResult;
-import spleetwaise.address.logic.commands.exceptions.CommandException;
 import spleetwaise.address.model.person.Person;
 import spleetwaise.address.testutil.Assert;
 import spleetwaise.address.testutil.TypicalPersons;
+import spleetwaise.transaction.logic.commands.exceptions.CommandException;
 import spleetwaise.transaction.model.ModelManager;
 import spleetwaise.transaction.model.transaction.Amount;
 import spleetwaise.transaction.model.transaction.Date;
@@ -21,12 +21,11 @@ import spleetwaise.transaction.model.transaction.Transaction;
 
 public class AddCommandTest {
 
-    private static Person testPerson = TypicalPersons.ALICE;
-    private static Amount testAmount = new Amount("+1.23");
-    private static Description testDescription = new Description("description");
-    private static Date testDate = new Date("01012024");
-
-    private static Transaction testTxn = new Transaction(testPerson, testAmount, testDescription, testDate);
+    private static final Person testPerson = TypicalPersons.ALICE;
+    private static final Amount testAmount = new Amount("+1.23");
+    private static final Description testDescription = new Description("description");
+    private static final Date testDate = new Date("01012024");
+    private static final Transaction testTxn = new Transaction(testPerson, testAmount, testDescription, testDate);
 
     @Test
     public void constructor_null_exceptionThrown() {
@@ -62,8 +61,8 @@ public class AddCommandTest {
         AddCommand cmd1 = new AddCommand(testTxn);
         AddCommand cmd2 = new AddCommand(testTxn);
 
-        assertTrue(cmd1.equals(cmd1));
-        assertTrue(cmd1.equals(cmd2));
+        assertEquals(cmd1, cmd1);
+        assertEquals(cmd1, cmd2);
     }
 
     @Test
@@ -72,14 +71,14 @@ public class AddCommandTest {
         Transaction testTxn2 = new Transaction(TypicalPersons.BOB, testAmount, testDescription, testDate);
         AddCommand cmd2 = new AddCommand(testTxn2);
 
-        assertFalse(cmd1.equals(cmd2));
+        assertNotEquals(cmd1, cmd2);
     }
 
     @Test
     public void equals_null_returnsFalse() {
         AddCommand cmd1 = new AddCommand(testTxn);
 
-        assertFalse(cmd1.equals(null));
+        assertNotEquals(null, cmd1);
     }
 
 }

--- a/src/test/java/spleetwaise/transaction/logic/commands/ClearCommandTest.java
+++ b/src/test/java/spleetwaise/transaction/logic/commands/ClearCommandTest.java
@@ -1,0 +1,29 @@
+package spleetwaise.transaction.logic.commands;
+
+import org.junit.jupiter.api.Test;
+
+import spleetwaise.transaction.model.Model;
+import spleetwaise.transaction.model.ModelManager;
+import spleetwaise.transaction.model.TransactionBook;
+import spleetwaise.transaction.testutil.TypicalTransactions;
+
+public class ClearCommandTest {
+
+    @Test
+    public void execute_emptyTransactionBook_success() {
+        Model model = new ModelManager();
+        Model expectedModel = new ModelManager();
+
+        CommandTestUtil.assertCommandSuccess(new ClearCommand(), model, ClearCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+
+    @Test
+    public void execute_nonEmptyTransactionBook_success() {
+        Model model = new ModelManager(TypicalTransactions.getTypicalTransactionBook());
+        Model expectedModel = new ModelManager(TypicalTransactions.getTypicalTransactionBook());
+        expectedModel.setTransactionBook(new TransactionBook());
+
+        CommandTestUtil.assertCommandSuccess(new ClearCommand(), model, ClearCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+
+}

--- a/src/test/java/spleetwaise/transaction/logic/commands/CommandTestUtil.java
+++ b/src/test/java/spleetwaise/transaction/logic/commands/CommandTestUtil.java
@@ -1,0 +1,38 @@
+package spleetwaise.transaction.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import spleetwaise.address.logic.commands.CommandResult;
+import spleetwaise.transaction.logic.commands.exceptions.CommandException;
+import spleetwaise.transaction.model.Model;
+
+/**
+ * Contains helper methods for testing transaction commands.
+ */
+public class CommandTestUtil {
+
+    /**
+     * Executes the given {@code command}, confirms that <br> - the returned {@link CommandResult} matches
+     * {@code expectedCommandResult} <br> - the {@code actualModel} matches {@code expectedModel}
+     */
+    public static void assertCommandSuccess(Command command, Model actualModel, CommandResult expectedCommandResult,
+                                            Model expectedModel) {
+        try {
+            CommandResult result = command.execute(actualModel);
+            assertEquals(expectedCommandResult, result);
+            assertEquals(expectedModel, actualModel);
+        } catch (CommandException ce) {
+            throw new AssertionError("Execution of txn command should not fail.", ce);
+        }
+    }
+
+    /**
+     * Convenience wrapper to {@link #assertCommandSuccess(Command, Model, CommandResult, Model)} that takes a string
+     * {@code expectedMessage}.
+     */
+    public static void assertCommandSuccess(Command command, Model actualModel, String expectedMessage,
+                                            Model expectedModel) {
+        CommandResult expectedCommandResult = new CommandResult(expectedMessage);
+        assertCommandSuccess(command, actualModel, expectedCommandResult, expectedModel);
+    }
+}

--- a/src/test/java/spleetwaise/transaction/testutil/TransactionBuilder.java
+++ b/src/test/java/spleetwaise/transaction/testutil/TransactionBuilder.java
@@ -1,0 +1,84 @@
+package spleetwaise.transaction.testutil;
+
+import spleetwaise.address.model.person.Person;
+import spleetwaise.address.testutil.TypicalPersons;
+import spleetwaise.transaction.model.transaction.Amount;
+import spleetwaise.transaction.model.transaction.Date;
+import spleetwaise.transaction.model.transaction.Description;
+import spleetwaise.transaction.model.transaction.Transaction;
+
+/**
+ * A utility class to help with building Transaction objects.
+ */
+public class TransactionBuilder {
+
+    private static final Person DEFAULT_PERSON = TypicalPersons.ALICE;
+    private static final String DEFAULT_POSITIVE_AMOUNT = "+1.23";
+    private static final String DEFAULT_NEGATIVE_AMOUNT = "-1.23";
+    private static final String DEFAULT_DESCRIPTION = "description";
+    private static final String DEFAULT_DATE = "01012024";
+
+    private Person person;
+    private Amount amount;
+    private Description description;
+    private Date date;
+
+    /**
+     * Creates a {@code TransactionBuilder} with the default details.
+     */
+    public TransactionBuilder() {
+        person = DEFAULT_PERSON;
+        amount = new Amount(DEFAULT_POSITIVE_AMOUNT);
+        description = new Description(DEFAULT_DESCRIPTION);
+        date = new Date(DEFAULT_DATE);
+    }
+
+    /**
+     * Initializes the TransactionBuilder with the data of {@code transactionToCopy}.
+     */
+    public TransactionBuilder(Transaction transactionToCopy) {
+        person = transactionToCopy.getPerson();
+        amount = transactionToCopy.getAmount();
+        description = transactionToCopy.getDescription();
+        date = transactionToCopy.getDate();
+    }
+
+    /**
+     * Sets the {@code Person} of the {@code Transaction} that we are building.
+     */
+    public TransactionBuilder withPerson(Person person) {
+        this.person = person;
+        return this;
+    }
+
+    /**
+     * Sets the {@code Amount} of the {@code Transaction} that we are building.
+     */
+    public TransactionBuilder withAmount(String amount) {
+        this.amount = new Amount(amount);
+        return this;
+    }
+
+    /**
+     * Sets the {@code Description} of the {@code Transaction} that we are building.
+     */
+    public TransactionBuilder withDescription(String description) {
+        this.description = new Description(description);
+        return this;
+    }
+
+    /**
+     * Sets the {@code Date} of the {@code Transaction} that we are building.
+     */
+    public TransactionBuilder withDate(String date) {
+        this.date = new Date(date);
+        return this;
+    }
+
+    /**
+     * Builds and returns the {@code Transaction} object.
+     */
+    public Transaction build() {
+        return new Transaction(person, amount, description, date);
+    }
+}

--- a/src/test/java/spleetwaise/transaction/testutil/TypicalTransactions.java
+++ b/src/test/java/spleetwaise/transaction/testutil/TypicalTransactions.java
@@ -1,0 +1,37 @@
+package spleetwaise.transaction.testutil;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import spleetwaise.address.testutil.TypicalPersons;
+import spleetwaise.transaction.model.TransactionBook;
+import spleetwaise.transaction.model.transaction.Transaction;
+
+/**
+ * A utility class containing a list of {@code Transaction} objects to be used in tests.
+ */
+public class TypicalTransactions {
+
+    public static final Transaction SEANOWESME =
+            new TransactionBuilder().withPerson(TypicalPersons.ALICE).withAmount("+9999999999.99")
+                    .withDescription("Sean owes me a lot for a landed property in Sentosa").withDate("10102024")
+                    .build();
+
+    private TypicalTransactions() {
+    } // prevents instantiation
+
+    /**
+     * Returns an {@code AddressBook} with all the typical persons.
+     */
+    public static TransactionBook getTypicalTransactionBook() {
+        TransactionBook tb = new TransactionBook();
+        for (Transaction transaction : getTypicalTransactions()) {
+            tb.addTransaction(transaction);
+        }
+        return tb;
+    }
+
+    public static List<Transaction> getTypicalTransactions() {
+        return new ArrayList<>(List.of(SEANOWESME)); // TODO: Add more default transactions for testing
+    }
+}


### PR DESCRIPTION
Closes #101 

Added a simple clearTxn command with basic logic to clear all transactions

Added a `commons` package under spleetwaise. @AY2425S1-CS2103-F13-1/developers require your reviews.

Add utility classes and data for transaction tests
- Added `TransactionBuilder` to help build `Transaction` objects.
- Added `TypicalTransactions` to provide typical `Transaction` objects for tests.
- Added `TransactionUtil` to provide utility methods for transaction-related tests.
- Refactored `LogicManager` to handle both AddressBook and Transaction commands.
- Updated `CommandException` to extend `SpleetWaiseCommandException`.