### PR TITLE
Change Amount validation

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -94,6 +94,23 @@ Examples:
 * `add n/John Doe p/98765432 e/johnd@example.com a/John street, block 123, #01-01`
 * `add n/Betsy Crowe t/friend e/betsycrowe@example.com a/Newgate Prison p/1234567 t/criminal`
 
+### Adding a transcation: `addTxn`
+
+Adds a transaction to the transaction book.
+
+Format: `addTxn p/PHONE_NUMBER amount/AMOUNT desc/TEST [date/DATE]`
+* The `PHONE_NUMBER` refers to the phone number associated to the person had a transaction with.
+* The `AMOUNT` accepts a decimal number with up to 2 decimal places. A `-` can be added as prefix to indicate negative 
+amount.
+* The `DATE` accepts date formatted in the form `DDMMYYYY` i.e.`10102024`.
+
+:bulb: **Tip:** If the transaction happened on the current day, the date parameter can be omitted.
+
+Examples:
+
+* `addTxn p/98765432 amt/12.3 desc/John paid me for dinner`
+* `addTxn p/98765432 amt/-12.3 desc/John owed me date/10102024`
+
 ### Listing all persons : `list`
 
 Shows a list of all persons in the address book.
@@ -228,8 +245,8 @@ the data of your previous AddressBook home folder.
 
 ## Command Summary for Transactions
 
-| Action    | Format, Examples                                                                                                                                                                 |
-|-----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **Add**   | `add p/PHONE_NUMBER amt/AMOUNT desc/DESCRIPTION date/DATE` <br> e.g., `addTxn p/99999999 amt/-9999999999.99 desc/Sean owes me a lot for a plot of land in sentosa date/10102024` |
-| **List**  | `listTxn`                                                                                                                                                                        |
-| **Clear** | `clearTxn`                                                                                                                                                                       |
+| Action    | Format, Examples                                                                                                                                                                   |
+|-----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Add**   | `add p/PHONE_NUMBER amt/AMOUNT desc/DESCRIPTION [date/DATE]` <br> e.g., `addTxn p/99999999 amt/-9999999999.99 desc/Sean owes me a lot for a plot of land in sentosa date/10102024` |
+| **List**  | `listTxn`                                                                                                                                                                          |
+| **Clear** | `clearTxn`                                                                                                                                                                         |

--- a/src/main/java/spleetwaise/transaction/model/transaction/Amount.java
+++ b/src/main/java/spleetwaise/transaction/model/transaction/Amount.java
@@ -14,12 +14,13 @@ import spleetwaise.address.commons.util.AppUtil;
 public class Amount {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Amount should only contain digits up to 2 decimal points delimited by . and prefixed with +/-";
+            "Amount should only contain digits up to 2 decimal points delimited by . and prefixed with - for negative"
+                    + " amounts";
 
     /*
      * The first character of amount must be + or - and only allow precision up to 2 decimal places
      */
-    public static final String VALIDATION_REGEX = "^(\\+|\\-)([\\d]+$|[\\d]+\\.[\\d]{1,2}$)";
+    public static final String VALIDATION_REGEX = "^(\\-)?([\\d]+$|[\\d]+\\.[\\d]{1,2}$)";
 
     private static final int MAX_DECIMAL_PLACES = 2;
 
@@ -56,8 +57,7 @@ public class Amount {
 
     @Override
     public String toString() {
-        String addPrefix = isNegative() ? "" : "+";
-        return String.format("%s%.2f", addPrefix, amount);
+        return String.format("%.2f", amount);
     }
 
     @Override

--- a/src/test/java/spleetwaise/address/logic/LogicManagerTest.java
+++ b/src/test/java/spleetwaise/address/logic/LogicManagerTest.java
@@ -93,9 +93,9 @@ public class LogicManagerTest {
         ParserUtil.setAddressBookModel(addressBookModel);
 
         // TODO: add a TransactionUtil class to handle generation of commands and expected messages
-        String addTxnCommand = "addTxn p/94351253 amt/+12.3 desc/Test date/01012024";
+        String addTxnCommand = "addTxn p/94351253 amt/12.3 desc/Test date/01012024";
         String expectedMessageSuccess = String.format(spleetwaise.transaction.logic.commands.AddCommand.MESSAGE_SUCCESS,
-            "[test-uuid] Alice Pauline(94351253): Test on 01/01/2024 for $+12.30");
+            "[test-uuid] Alice Pauline(94351253): Test on 01/01/2024 for $12.30");
 
         assertCommandSuccess(listCommand, ListCommand.MESSAGE_SUCCESS, addressBookModel, transactionModel);
         IdUtil.setDeterminate(true);

--- a/src/test/java/spleetwaise/transaction/logic/commands/AddCommandTest.java
+++ b/src/test/java/spleetwaise/transaction/logic/commands/AddCommandTest.java
@@ -22,7 +22,7 @@ import spleetwaise.transaction.model.transaction.Transaction;
 public class AddCommandTest {
 
     private static final Person testPerson = TypicalPersons.ALICE;
-    private static final Amount testAmount = new Amount("+1.23");
+    private static final Amount testAmount = new Amount("1.23");
     private static final Description testDescription = new Description("description");
     private static final Date testDate = new Date("01012024");
     private static final Transaction testTxn = new Transaction(testPerson, testAmount, testDescription, testDate);
@@ -39,7 +39,7 @@ public class AddCommandTest {
         AddCommand cmd = new AddCommand(testTxn);
         CommandResult cmdRes = assertDoesNotThrow(() -> cmd.execute(modelManager));
 
-        String expectedString = String.format("[%s] Alice Pauline(94351253): description on 01/01/2024 for $+1.23",
+        String expectedString = String.format("[%s] Alice Pauline(94351253): description on 01/01/2024 for $1.23",
                 testTxn.getId());
         assertEquals(String.format(AddCommand.MESSAGE_SUCCESS, expectedString),
                 cmdRes.getFeedbackToUser());

--- a/src/test/java/spleetwaise/transaction/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/spleetwaise/transaction/logic/parser/AddCommandParserTest.java
@@ -19,7 +19,7 @@ import spleetwaise.transaction.model.transaction.Transaction;
 public class AddCommandParserTest {
 
     private static Person testPerson = TypicalPersons.ALICE;
-    private static Amount testAmount = new Amount("+1.23");
+    private static Amount testAmount = new Amount("1.23");
     private static Description testDescription = new Description("description");
     private static Date testDate = new Date("01012024");
 
@@ -31,7 +31,7 @@ public class AddCommandParserTest {
         addressBookModel.addPerson(testPerson);
         ParserUtil.setAddressBookModel(addressBookModel);
 
-        String userInput = " p/94351253 amt/+1.23 desc/description";
+        String userInput = " p/94351253 amt/1.23 desc/description";
         Transaction txn = new Transaction(testPerson, testAmount, testDescription);
         assertParseSuccess(parser, userInput, new AddCommand(txn));
     }
@@ -42,7 +42,7 @@ public class AddCommandParserTest {
         addressBookModel.addPerson(testPerson);
         ParserUtil.setAddressBookModel(addressBookModel);
 
-        String userInput = " p/94351253 amt/+1.23 desc/description date/01012024";
+        String userInput = " p/94351253 amt/1.23 desc/description date/01012024";
         Transaction txn = new Transaction(testPerson, testAmount, testDescription, testDate);
         assertParseSuccess(parser, userInput, new AddCommand(txn));
     }
@@ -52,7 +52,7 @@ public class AddCommandParserTest {
         ModelManager addressBookModel = new ModelManager();
         ParserUtil.setAddressBookModel(addressBookModel);
 
-        String userInput = " p/94351253 amt/+1.23 desc/description date/01012024";
+        String userInput = " p/94351253 amt/1.23 desc/description date/01012024";
         assertParseFailure(parser, userInput, Phone.MESSAGE_CONSTRAINTS);
     }
 
@@ -62,7 +62,7 @@ public class AddCommandParserTest {
         addressBookModel.addPerson(testPerson);
         ParserUtil.setAddressBookModel(addressBookModel);
 
-        String userInput = " p/94351253 amt/+1.234 desc/description date/01012024";
+        String userInput = " p/94351253 amt/1.234 desc/description date/01012024";
         assertParseFailure(parser, userInput, Amount.MESSAGE_CONSTRAINTS);
     }
 
@@ -72,7 +72,7 @@ public class AddCommandParserTest {
         addressBookModel.addPerson(testPerson);
         ParserUtil.setAddressBookModel(addressBookModel);
 
-        String userInput = " p/94351253 amt/+1.23 desc/ date/01012024";
+        String userInput = " p/94351253 amt/1.23 desc/ date/01012024";
         assertParseFailure(parser, userInput, Description.MESSAGE_CONSTRAINTS);
     }
 
@@ -82,7 +82,7 @@ public class AddCommandParserTest {
         addressBookModel.addPerson(testPerson);
         ParserUtil.setAddressBookModel(addressBookModel);
 
-        String userInput = " p/94351253 amt/+1.23 desc/test date/2024";
+        String userInput = " p/94351253 amt/1.23 desc/test date/2024";
         assertParseFailure(parser, userInput, Date.MESSAGE_CONSTRAINTS);
     }
 

--- a/src/test/java/spleetwaise/transaction/model/ModelManagerTest.java
+++ b/src/test/java/spleetwaise/transaction/model/ModelManagerTest.java
@@ -20,7 +20,7 @@ import spleetwaise.transaction.model.transaction.Transaction;
 public class ModelManagerTest {
 
     private static Person testPerson = TypicalPersons.ALICE;
-    private static Amount testAmount = new Amount("+1.23");
+    private static Amount testAmount = new Amount("1.23");
     private static Description testDescription = new Description("1");
     private static Date testDate = new Date("01012024");
 

--- a/src/test/java/spleetwaise/transaction/model/TransactionBookTest.java
+++ b/src/test/java/spleetwaise/transaction/model/TransactionBookTest.java
@@ -21,7 +21,7 @@ import spleetwaise.transaction.model.transaction.exceptions.DuplicateTransaction
 public class TransactionBookTest {
 
     private static Person testPerson = TypicalPersons.ALICE;
-    private static Amount testAmount = new Amount("+1.23");
+    private static Amount testAmount = new Amount("1.23");
     private static Description testDescription = new Description("description");
     private static Date testDate = new Date("01012024");
 

--- a/src/test/java/spleetwaise/transaction/model/transaction/AmountTest.java
+++ b/src/test/java/spleetwaise/transaction/model/transaction/AmountTest.java
@@ -42,35 +42,35 @@ public class AmountTest {
         assertFalse(Amount.isValidAmount("alphanumeric"));
 
         // Test numeric input with wrong format
-        assertFalse(Amount.isValidAmount("100"));
-        assertFalse(Amount.isValidAmount("100.001"));
+        assertFalse(Amount.isValidAmount("+100"));
+        assertFalse(Amount.isValidAmount("+100.001"));
 
         // Test zero inputs
-        assertFalse(Amount.isValidAmount("+0"));
+        assertFalse(Amount.isValidAmount("0"));
         assertFalse(Amount.isValidAmount("-0"));
-        assertFalse(Amount.isValidAmount("+0.0"));
+        assertFalse(Amount.isValidAmount("0.0"));
         assertFalse(Amount.isValidAmount("-0.0"));
-        assertFalse(Amount.isValidAmount("+0.00"));
+        assertFalse(Amount.isValidAmount("0.00"));
         assertFalse(Amount.isValidAmount("-0.00"));
     }
 
     @Test
     public void isValidAmount_validArgument_returnsTrue() {
-        assertTrue(Amount.isValidAmount("+100"));
+        assertTrue(Amount.isValidAmount("100"));
         assertTrue(Amount.isValidAmount("-100"));
-        assertTrue(Amount.isValidAmount("+100.0"));
+        assertTrue(Amount.isValidAmount("100.0"));
         assertTrue(Amount.isValidAmount("-100.0"));
-        assertTrue(Amount.isValidAmount("+100.00"));
+        assertTrue(Amount.isValidAmount("100.00"));
         assertTrue(Amount.isValidAmount("-100.00"));
-        assertTrue(Amount.isValidAmount("+0.01"));
+        assertTrue(Amount.isValidAmount("0.01"));
         assertTrue(Amount.isValidAmount("-0.01"));
-        assertTrue(Amount.isValidAmount("+0.1"));
+        assertTrue(Amount.isValidAmount("0.1"));
         assertTrue(Amount.isValidAmount("-0.1"));
     }
 
     @Test
     public void isNegative_success() {
-        Amount amt1 = new Amount("+100");
+        Amount amt1 = new Amount("100");
         assertFalse(amt1.isNegative());
 
         Amount amt2 = new Amount("-100");
@@ -79,24 +79,24 @@ public class AmountTest {
 
     @Test
     public void equals_validArgument_returnsTrue() {
-        Amount amt1 = new Amount("+100");
-        Amount amt2 = new Amount("+100.0");
+        Amount amt1 = new Amount("100");
+        Amount amt2 = new Amount("100.0");
         assertTrue(amt1.equals(amt2));
 
-        amt1 = new Amount("+100");
+        amt1 = new Amount("100");
         assertTrue(amt1.equals(amt1));
     }
 
     @Test
     public void equals_invalidArgument_returnsFalse() {
-        Amount amt1 = new Amount("+100");
+        Amount amt1 = new Amount("100");
         assertFalse(amt1.equals(null));
     }
 
     @Test
     public void toString_correctFormat() {
-        Amount amt1 = new Amount("+0.12");
-        assertEquals("+0.12", amt1.toString());
+        Amount amt1 = new Amount("0.12");
+        assertEquals("0.12", amt1.toString());
 
         amt1 = new Amount("-0.12");
         assertEquals("-0.12", amt1.toString());

--- a/src/test/java/spleetwaise/transaction/model/transaction/TransactionTest.java
+++ b/src/test/java/spleetwaise/transaction/model/transaction/TransactionTest.java
@@ -14,7 +14,7 @@ import spleetwaise.address.testutil.TypicalPersons;
 public class TransactionTest {
 
     private static Person testPerson = TypicalPersons.ALICE;
-    private static Amount testAmount = new Amount("+1.23");
+    private static Amount testAmount = new Amount("1.23");
     private static Description testDescription = new Description("description");
     private static Date testDate = new Date("01012024");
 
@@ -76,7 +76,7 @@ public class TransactionTest {
     public void toString_success() {
         Transaction txn1 = new Transaction(testPerson, testAmount, testDescription, testDate);
 
-        assertEquals(String.format("[%s] Alice Pauline(94351253): description on 01/01/2024 for $+1.23", txn1.getId()),
+        assertEquals(String.format("[%s] Alice Pauline(94351253): description on 01/01/2024 for $1.23", txn1.getId()),
                 txn1.toString());
     }
 

--- a/src/test/java/spleetwaise/transaction/testutil/TransactionBuilder.java
+++ b/src/test/java/spleetwaise/transaction/testutil/TransactionBuilder.java
@@ -12,11 +12,11 @@ import spleetwaise.transaction.model.transaction.Transaction;
  */
 public class TransactionBuilder {
 
-    public static final String DEFAULT_AMOUNT = "+12.3";
+    public static final String DEFAULT_AMOUNT = "12.3";
     public static final String DEFAULT_DESCRIPTION = "Test";
     public static final String DEFAULT_DATE = "01012024";
     private static final Person DEFAULT_PERSON = TypicalPersons.ALICE;
-    private static final String DEFAULT_POSITIVE_AMOUNT = "+1.23";
+    private static final String DEFAULT_POSITIVE_AMOUNT = "1.23";
     private static final String DEFAULT_NEGATIVE_AMOUNT = "-1.23";
 
     private Person person;

--- a/src/test/java/spleetwaise/transaction/testutil/TransactionUtil.java
+++ b/src/test/java/spleetwaise/transaction/testutil/TransactionUtil.java
@@ -13,6 +13,6 @@ public class TransactionUtil {
      */
     public static String getAddCommand() {
         // Using TypicalPerson.ALICE contact details
-        return AddCommand.COMMAND_WORD + " p/94351253 amt/+12.3 desc/Test";
+        return AddCommand.COMMAND_WORD + " p/94351253 amt/12.3 desc/Test";
     }
 }

--- a/src/test/java/spleetwaise/transaction/testutil/TypicalTransactions.java
+++ b/src/test/java/spleetwaise/transaction/testutil/TypicalTransactions.java
@@ -13,7 +13,7 @@ import spleetwaise.transaction.model.transaction.Transaction;
 public class TypicalTransactions {
 
     public static final Transaction SEANOWESME =
-            new TransactionBuilder().withPerson(TypicalPersons.ALICE).withAmount("+9999999999.99")
+            new TransactionBuilder().withPerson(TypicalPersons.ALICE).withAmount("9999999999.99")
                     .withDescription("Sean owes me a lot for a landed property in Sentosa").withDate("10102024")
                     .build();
 


### PR DESCRIPTION
This issue resolves #121.
The amount class now rejects the `+` prefixes for positive values.  No prefix is required for positive values while a `-` will still be required for negative values passed into amount. 