### PR TITLE
Add remark command and related functionality to addcommand and editcommand

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -156,6 +156,22 @@ Examples:
 * `find alex david` returns `Alex Yeoh`, `David Li`<br>
   ![result for 'find alex david'](images/findAlexDavidResult.png)
 
+### Adding Remarks for a person : `remark`
+
+Add remarks for the specified person from the address book.
+
+Format: `remark INDEX r/REMARK`
+
+* Add remarks for the person at the specified `INDEX`.
+* The index refers to the index number shown in the displayed person list.
+* The index **must be a positive integer** 1, 2, 3, …​
+
+Examples:
+
+* `list` followed by `remark 2 r/remark for person 2` adds remarks for the 2nd person in the address book.
+* `find Betsy` followed by `remark 1 r/remark for betsy` adds remarks for the 1st person in the results of the `find`
+  command.
+
 ### Deleting a person : `delete`
 
 Deletes the specified person from the address book.
@@ -231,15 +247,16 @@ the data of your previous AddressBook home folder.
 
 ## Command Summary for Address Book
 
-| Action     | Format, Examples                                                                                                                                                      |
-|------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **Add**    | `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [t/TAG]…​` <br> e.g., `add n/James Ho p/22224444 e/jamesho@example.com a/123, Clementi Rd, 1234665 t/friend t/colleague` |
-| **Clear**  | `clear`                                                                                                                                                               |
-| **Delete** | `delete INDEX`<br> e.g., `delete 3`                                                                                                                                   |
-| **Edit**   | `edit INDEX [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [a/ADDRESS] [t/TAG]…​`<br> e.g.,`edit 2 n/James Lee e/jameslee@example.com`                                           |
-| **Find**   | `find KEYWORD [MORE_KEYWORDS]`<br> e.g., `find James Jake`                                                                                                            |
-| **List**   | `list`                                                                                                                                                                |
-| **Help**   | `help`                                                                                                                                                                |
+| Action     | Format, Examples                                                                                                                                                                                                           |
+|------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Add**    | `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [r/REMARK] [t/TAG]…​` <br> e.g., `add n/James Ho p/22224444 e/jamesho@example.com a/123, Clementi Rd, 1234665 r/James is poor af, do not loan him money t/friend t/colleague` |
+| **Clear**  | `clear`                                                                                                                                                                                                                    |
+| **Delete** | `delete INDEX`<br> e.g., `delete 3`                                                                                                                                                                                        |
+| **Edit**   | `edit INDEX [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [a/ADDRESS] [r/REMARK] [t/TAG]…​`<br> e.g.,`edit 2 n/James Lee e/jameslee@example.com`                                                                                     |
+| **Find**   | `find KEYWORD [MORE_KEYWORDS]`<br> e.g., `find James Jake`                                                                                                                                                                 |
+| **List**   | `list`                                                                                                                                                                                                                     |
+| **REMARK** | `remark INDEX r/REMARK`                                                                                                                                                                                                    |
+| **Help**   | `help`                                                                                                                                                                                                                     |
 
 --------------------------------------------------------------------------------------------------------------------
 

--- a/src/main/java/spleetwaise/address/logic/commands/AddCommand.java
+++ b/src/main/java/spleetwaise/address/logic/commands/AddCommand.java
@@ -5,6 +5,7 @@ import static spleetwaise.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static spleetwaise.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static spleetwaise.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static spleetwaise.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static spleetwaise.address.logic.parser.CliSyntax.PREFIX_REMARK;
 import static spleetwaise.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import spleetwaise.address.commons.util.ToStringBuilder;
@@ -26,12 +27,14 @@ public class AddCommand extends Command {
             + PREFIX_PHONE + "PHONE "
             + PREFIX_EMAIL + "EMAIL "
             + PREFIX_ADDRESS + "ADDRESS "
+            + PREFIX_REMARK + "REMARK "
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "John Doe "
             + PREFIX_PHONE + "98765432 "
             + PREFIX_EMAIL + "johnd@example.com "
             + PREFIX_ADDRESS + "311, Clementi Ave 2, #02-25 "
+            + PREFIX_REMARK + "This guy owes me money "
             + PREFIX_TAG + "friends "
             + PREFIX_TAG + "owesMoney";
 

--- a/src/main/java/spleetwaise/address/logic/commands/AddCommand.java
+++ b/src/main/java/spleetwaise/address/logic/commands/AddCommand.java
@@ -27,7 +27,7 @@ public class AddCommand extends Command {
             + PREFIX_PHONE + "PHONE "
             + PREFIX_EMAIL + "EMAIL "
             + PREFIX_ADDRESS + "ADDRESS "
-            + PREFIX_REMARK + "REMARK "
+            + "[" + PREFIX_REMARK + "REMARK] "
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "John Doe "

--- a/src/main/java/spleetwaise/address/logic/commands/EditCommand.java
+++ b/src/main/java/spleetwaise/address/logic/commands/EditCommand.java
@@ -5,6 +5,7 @@ import static spleetwaise.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static spleetwaise.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static spleetwaise.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static spleetwaise.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static spleetwaise.address.logic.parser.CliSyntax.PREFIX_REMARK;
 import static spleetwaise.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.Collections;
@@ -43,6 +44,7 @@ public class EditCommand extends Command {
             + "[" + PREFIX_PHONE + "PHONE] "
             + "[" + PREFIX_EMAIL + "EMAIL] "
             + "[" + PREFIX_ADDRESS + "ADDRESS] "
+            + "[" + PREFIX_REMARK + "REMARK] "
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_PHONE + "91234567 "
@@ -79,7 +81,7 @@ public class EditCommand extends Command {
         Phone updatedPhone = editPersonDescriptor.getPhone().orElse(personToEdit.getPhone());
         Email updatedEmail = editPersonDescriptor.getEmail().orElse(personToEdit.getEmail());
         Address updatedAddress = editPersonDescriptor.getAddress().orElse(personToEdit.getAddress());
-        Remark updatedRemark = personToEdit.getRemark();
+        Remark updatedRemark = editPersonDescriptor.getRemark().orElse(personToEdit.getRemark());
         Set<Tag> updatedTags = editPersonDescriptor.getTags().orElse(personToEdit.getTags());
 
         return new Person(id, updatedName, updatedPhone, updatedEmail, updatedAddress, updatedRemark, updatedTags);
@@ -143,6 +145,7 @@ public class EditCommand extends Command {
         private Phone phone;
         private Email email;
         private Address address;
+        private Remark remark;
         private Set<Tag> tags;
 
         public EditPersonDescriptor() {
@@ -157,6 +160,7 @@ public class EditCommand extends Command {
             setPhone(toCopy.phone);
             setEmail(toCopy.email);
             setAddress(toCopy.address);
+            setRemark(toCopy.remark);
             setTags(toCopy.tags);
         }
 
@@ -164,7 +168,7 @@ public class EditCommand extends Command {
          * Returns true if at least one field is edited.
          */
         public boolean isAnyFieldEdited() {
-            return CollectionUtil.isAnyNonNull(name, phone, email, address, tags);
+            return CollectionUtil.isAnyNonNull(name, phone, email, address, remark, tags);
         }
 
         public Optional<String> getId() {
@@ -207,6 +211,14 @@ public class EditCommand extends Command {
             this.address = address;
         }
 
+        public Optional<Remark> getRemark() {
+            return Optional.ofNullable(remark);
+        }
+
+        public void setRemark(Remark remark) {
+            this.remark = remark;
+        }
+
         /**
          * Returns an unmodifiable tag set, which throws {@code UnsupportedOperationException} if modification is
          * attempted. Returns {@code Optional#empty()} if {@code tags} is null.
@@ -238,6 +250,7 @@ public class EditCommand extends Command {
                     && Objects.equals(phone, otherEditPersonDescriptor.phone)
                     && Objects.equals(email, otherEditPersonDescriptor.email)
                     && Objects.equals(address, otherEditPersonDescriptor.address)
+                    && Objects.equals(remark, otherEditPersonDescriptor.remark)
                     && Objects.equals(tags, otherEditPersonDescriptor.tags);
         }
 
@@ -248,6 +261,7 @@ public class EditCommand extends Command {
                     .add("phone", phone)
                     .add("email", email)
                     .add("address", address)
+                    .add("remark", remark)
                     .add("tags", tags)
                     .toString();
         }

--- a/src/main/java/spleetwaise/address/logic/commands/EditCommand.java
+++ b/src/main/java/spleetwaise/address/logic/commands/EditCommand.java
@@ -25,6 +25,7 @@ import spleetwaise.address.model.person.Email;
 import spleetwaise.address.model.person.Name;
 import spleetwaise.address.model.person.Person;
 import spleetwaise.address.model.person.Phone;
+import spleetwaise.address.model.person.Remark;
 import spleetwaise.address.model.tag.Tag;
 
 /**
@@ -78,9 +79,10 @@ public class EditCommand extends Command {
         Phone updatedPhone = editPersonDescriptor.getPhone().orElse(personToEdit.getPhone());
         Email updatedEmail = editPersonDescriptor.getEmail().orElse(personToEdit.getEmail());
         Address updatedAddress = editPersonDescriptor.getAddress().orElse(personToEdit.getAddress());
+        Remark updatedRemark = personToEdit.getRemark();
         Set<Tag> updatedTags = editPersonDescriptor.getTags().orElse(personToEdit.getTags());
 
-        return new Person(id, updatedName, updatedPhone, updatedEmail, updatedAddress, updatedTags);
+        return new Person(id, updatedName, updatedPhone, updatedEmail, updatedAddress, updatedRemark, updatedTags);
     }
 
     public EditPersonDescriptor getDescriptior() {

--- a/src/main/java/spleetwaise/address/logic/commands/RemarkCommand.java
+++ b/src/main/java/spleetwaise/address/logic/commands/RemarkCommand.java
@@ -1,0 +1,86 @@
+package spleetwaise.address.logic.commands;
+
+import static spleetwaise.address.commons.util.CollectionUtil.requireAllNonNull;
+import static spleetwaise.address.logic.parser.CliSyntax.PREFIX_REMARK;
+import static spleetwaise.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+
+import java.util.List;
+
+import spleetwaise.address.commons.core.index.Index;
+import spleetwaise.address.logic.Messages;
+import spleetwaise.address.logic.commands.exceptions.CommandException;
+import spleetwaise.address.model.Model;
+import spleetwaise.address.model.person.Person;
+import spleetwaise.address.model.person.Remark;
+
+/**
+ * Changes the remark of an existing person in the address book.
+ */
+public class RemarkCommand extends Command {
+
+    public static final String COMMAND_WORD = "remark";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the remark of the person identified "
+            + "by the index number used in the last person listing. "
+            + "Existing remark will be overwritten by the input.\n" + "Parameters: INDEX (must be a positive integer) "
+            + PREFIX_REMARK + "[REMARK]\n" + "Example: " + COMMAND_WORD + " 1 " + PREFIX_REMARK + "Likes to swim.";
+    public static final String MESSAGE_ADD_REMARK_SUCCESS = "Added remark to Person: %1$s";
+    public static final String MESSAGE_DELETE_REMARK_SUCCESS = "Removed remark from Person: %1$s";
+
+    private final Index index;
+    private final Remark remark;
+
+    /**
+     * @param index  of the person in the filtered person list to edit the remark
+     * @param remark of the person to be updated to
+     */
+    public RemarkCommand(Index index, Remark remark) {
+        requireAllNonNull(index, remark);
+
+        this.index = index;
+        this.remark = remark;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        List<Person> lastShownList = model.getFilteredPersonList();
+
+        if (index.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        Person personToEdit = lastShownList.get(index.getZeroBased());
+        Person editedPerson = new Person(personToEdit.getName(), personToEdit.getPhone(), personToEdit.getEmail(),
+                personToEdit.getAddress(), remark, personToEdit.getTags());
+
+        model.setPerson(personToEdit, editedPerson);
+        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+
+        return new CommandResult(generateSuccessMessage(editedPerson));
+    }
+
+    /**
+     * Generates a command execution success message based on whether the remark is added to or removed from
+     * {@code personToEdit}.
+     */
+    private String generateSuccessMessage(Person personToEdit) {
+        String message = !remark.value.isEmpty() ? MESSAGE_ADD_REMARK_SUCCESS : MESSAGE_DELETE_REMARK_SUCCESS;
+        return String.format(message, personToEdit);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof RemarkCommand e)) {
+            return false;
+        }
+
+        // state check
+        return index.equals(e.index) && remark.equals(e.remark);
+    }
+}

--- a/src/main/java/spleetwaise/address/logic/commands/RemarkCommand.java
+++ b/src/main/java/spleetwaise/address/logic/commands/RemarkCommand.java
@@ -50,8 +50,9 @@ public class RemarkCommand extends Command {
         }
 
         Person personToEdit = lastShownList.get(index.getZeroBased());
-        Person editedPerson = new Person(personToEdit.getName(), personToEdit.getPhone(), personToEdit.getEmail(),
-                personToEdit.getAddress(), remark, personToEdit.getTags());
+        Person editedPerson = new Person(personToEdit.getId(), personToEdit.getName(), personToEdit.getPhone(),
+                personToEdit.getEmail(), personToEdit.getAddress(), remark, personToEdit.getTags()
+        );
 
         model.setPerson(personToEdit, editedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);

--- a/src/main/java/spleetwaise/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/spleetwaise/address/logic/parser/AddCommandParser.java
@@ -17,6 +17,7 @@ import spleetwaise.address.model.person.Email;
 import spleetwaise.address.model.person.Name;
 import spleetwaise.address.model.person.Person;
 import spleetwaise.address.model.person.Phone;
+import spleetwaise.address.model.person.Remark;
 import spleetwaise.address.model.tag.Tag;
 
 /**
@@ -25,13 +26,22 @@ import spleetwaise.address.model.tag.Tag;
 public class AddCommandParser implements Parser<AddCommand> {
 
     /**
-     * Parses the given {@code String} of arguments in the context of the AddCommand
-     * and returns an AddCommand object for execution.
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the AddCommand and returns an AddCommand object
+     * for execution.
+     *
      * @throws ParseException if the user input does not conform the expected format
      */
     public AddCommand parse(String args) throws ParseException {
-        ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(
+                args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
 
         if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_ADDRESS, PREFIX_PHONE, PREFIX_EMAIL)
                 || !argMultimap.getPreamble().isEmpty()) {
@@ -43,19 +53,11 @@ public class AddCommandParser implements Parser<AddCommand> {
         Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
         Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
         Address address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get());
+        Remark remark = new Remark(""); // add command does not allow adding remarks straight away
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 
-        Person person = new Person(name, phone, email, address, tagList);
+        Person person = new Person(name, phone, email, address, remark, tagList);
 
         return new AddCommand(person);
     }
-
-    /**
-     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
-     * {@code ArgumentMultimap}.
-     */
-    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
-        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
-    }
-
 }

--- a/src/main/java/spleetwaise/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/spleetwaise/address/logic/parser/AddCommandParser.java
@@ -5,6 +5,7 @@ import static spleetwaise.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static spleetwaise.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static spleetwaise.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static spleetwaise.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static spleetwaise.address.logic.parser.CliSyntax.PREFIX_REMARK;
 import static spleetwaise.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.Set;
@@ -41,19 +42,20 @@ public class AddCommandParser implements Parser<AddCommand> {
      */
     public AddCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(
-                args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
+                args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_REMARK, PREFIX_TAG);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_ADDRESS, PREFIX_PHONE, PREFIX_EMAIL)
+        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
         }
 
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS);
+        argMultimap.verifyNoDuplicatePrefixesFor(
+                PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_REMARK);
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
         Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
         Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
         Address address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get());
-        Remark remark = new Remark(""); // add command does not allow adding remarks straight away
+        Remark remark = ParserUtil.parseRemark(argMultimap.getValue(PREFIX_REMARK).orElse(""));
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 
         Person person = new Person(name, phone, email, address, remark, tagList);

--- a/src/main/java/spleetwaise/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/spleetwaise/address/logic/parser/AddressBookParser.java
@@ -71,7 +71,6 @@ public class AddressBookParser {
         case RemarkCommand.COMMAND_WORD:
             return new RemarkCommandParser().parse(arguments);
 
-
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();
 

--- a/src/main/java/spleetwaise/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/spleetwaise/address/logic/parser/AddressBookParser.java
@@ -14,6 +14,7 @@ import spleetwaise.address.logic.commands.ExitCommand;
 import spleetwaise.address.logic.commands.FindCommand;
 import spleetwaise.address.logic.commands.HelpCommand;
 import spleetwaise.address.logic.commands.ListCommand;
+import spleetwaise.address.logic.commands.RemarkCommand;
 import spleetwaise.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -66,6 +67,10 @@ public class AddressBookParser {
 
         case ListCommand.COMMAND_WORD:
             return new ListCommand();
+
+        case RemarkCommand.COMMAND_WORD:
+            return new RemarkCommandParser().parse(arguments);
+
 
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();

--- a/src/main/java/spleetwaise/address/logic/parser/CliSyntax.java
+++ b/src/main/java/spleetwaise/address/logic/parser/CliSyntax.java
@@ -10,6 +10,7 @@ public class CliSyntax {
     public static final Prefix PREFIX_PHONE = new Prefix("p/");
     public static final Prefix PREFIX_EMAIL = new Prefix("e/");
     public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
+    public static final Prefix PREFIX_REMARK = new Prefix("r/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
 
 }

--- a/src/main/java/spleetwaise/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/spleetwaise/address/logic/parser/EditCommandParser.java
@@ -6,6 +6,7 @@ import static spleetwaise.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static spleetwaise.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static spleetwaise.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static spleetwaise.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static spleetwaise.address.logic.parser.CliSyntax.PREFIX_REMARK;
 import static spleetwaise.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.Collection;
@@ -25,14 +26,16 @@ import spleetwaise.address.model.tag.Tag;
 public class EditCommandParser implements Parser<EditCommand> {
 
     /**
-     * Parses the given {@code String} of arguments in the context of the EditCommand
-     * and returns an EditCommand object for execution.
+     * Parses the given {@code String} of arguments in the context of the EditCommand and returns an EditCommand object
+     * for execution.
+     *
      * @throws ParseException if the user input does not conform the expected format
      */
     public EditCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
+                ArgumentTokenizer.tokenize(
+                        args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_REMARK, PREFIX_TAG);
 
         Index index;
 
@@ -42,7 +45,8 @@ public class EditCommandParser implements Parser<EditCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE), pe);
         }
 
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS);
+        argMultimap.verifyNoDuplicatePrefixesFor(
+                PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_REMARK);
 
         EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();
 
@@ -58,6 +62,9 @@ public class EditCommandParser implements Parser<EditCommand> {
         if (argMultimap.getValue(PREFIX_ADDRESS).isPresent()) {
             editPersonDescriptor.setAddress(ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get()));
         }
+        if (argMultimap.getValue(PREFIX_REMARK).isPresent()) {
+            editPersonDescriptor.setRemark(ParserUtil.parseRemark(argMultimap.getValue(PREFIX_REMARK).get()));
+        }
         parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editPersonDescriptor::setTags);
 
         if (!editPersonDescriptor.isAnyFieldEdited()) {
@@ -68,9 +75,9 @@ public class EditCommandParser implements Parser<EditCommand> {
     }
 
     /**
-     * Parses {@code Collection<String> tags} into a {@code Set<Tag>} if {@code tags} is non-empty.
-     * If {@code tags} contain only one element which is an empty string, it will be parsed into a
-     * {@code Set<Tag>} containing zero tags.
+     * Parses {@code Collection<String> tags} into a {@code Set<Tag>} if {@code tags} is non-empty. If {@code tags}
+     * contain only one element which is an empty string, it will be parsed into a {@code Set<Tag>} containing zero
+     * tags.
      */
     private Optional<Set<Tag>> parseTagsForEdit(Collection<String> tags) throws ParseException {
         assert tags != null;

--- a/src/main/java/spleetwaise/address/logic/parser/ParserUtil.java
+++ b/src/main/java/spleetwaise/address/logic/parser/ParserUtil.java
@@ -13,6 +13,7 @@ import spleetwaise.address.model.person.Address;
 import spleetwaise.address.model.person.Email;
 import spleetwaise.address.model.person.Name;
 import spleetwaise.address.model.person.Phone;
+import spleetwaise.address.model.person.Remark;
 import spleetwaise.address.model.tag.Tag;
 
 /**
@@ -93,6 +94,21 @@ public class ParserUtil {
             throw new ParseException(Email.MESSAGE_CONSTRAINTS);
         }
         return new Email(trimmedEmail);
+    }
+
+    /**
+     * Parses a {@code String remark} into an {@code remark}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code remark} is invalid.
+     */
+    public static Remark parseRemark(String remark) throws ParseException {
+        requireNonNull(remark);
+        String trimmedRemark = remark.trim();
+        if (!Remark.isValidRemark(trimmedRemark)) {
+            throw new ParseException(Remark.MESSAGE_CONSTRAINTS);
+        }
+        return new Remark(trimmedRemark);
     }
 
     /**

--- a/src/main/java/spleetwaise/address/logic/parser/RemarkCommandParser.java
+++ b/src/main/java/spleetwaise/address/logic/parser/RemarkCommandParser.java
@@ -1,0 +1,38 @@
+package spleetwaise.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static spleetwaise.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static spleetwaise.address.logic.parser.CliSyntax.PREFIX_REMARK;
+
+import spleetwaise.address.commons.core.index.Index;
+import spleetwaise.address.commons.exceptions.IllegalValueException;
+import spleetwaise.address.logic.commands.RemarkCommand;
+import spleetwaise.address.logic.parser.exceptions.ParseException;
+import spleetwaise.address.model.person.Remark;
+
+/**
+ * Parses input arguments and creates a new {@code RemarkCommand} object
+ */
+public class RemarkCommandParser implements Parser<RemarkCommand> {
+    /**
+     * Parses the given {@code String} of arguments in the context of the {@code RemarkCommand} and returns a
+     * {@code RemarkCommand} object for execution.
+     *
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public RemarkCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_REMARK);
+
+        Index index;
+        try {
+            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+        } catch (IllegalValueException ive) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, RemarkCommand.MESSAGE_USAGE), ive);
+        }
+
+        String remark = argMultimap.getValue(PREFIX_REMARK).orElse("");
+
+        return new RemarkCommand(index, new Remark(remark));
+    }
+}

--- a/src/main/java/spleetwaise/address/model/person/Person.java
+++ b/src/main/java/spleetwaise/address/model/person/Person.java
@@ -30,7 +30,7 @@ public class Person {
      * Every field must be present and not null.
      */
     public Person(String id, Name name, Phone phone, Email email, Address address, Remark remark, Set<Tag> tags) {
-        CollectionUtil.requireAllNonNull(name, phone, email, address, tags);
+        CollectionUtil.requireAllNonNull(name, phone, email, address, remark, tags);
         this.id = id;
         this.name = name;
         this.phone = phone;
@@ -115,6 +115,7 @@ public class Person {
                 && phone.equals(otherPerson.phone)
                 && email.equals(otherPerson.email)
                 && address.equals(otherPerson.address)
+                && remark.equals(otherPerson.remark)
                 && tags.equals(otherPerson.tags);
     }
 
@@ -130,6 +131,7 @@ public class Person {
                 .add("phone", phone)
                 .add("email", email)
                 .add("address", address)
+                .add("remark", remark)
                 .add("tags", tags)
                 .toString();
     }

--- a/src/main/java/spleetwaise/address/model/person/Person.java
+++ b/src/main/java/spleetwaise/address/model/person/Person.java
@@ -20,6 +20,7 @@ public class Person {
     private final Name name;
     private final Phone phone;
     private final Email email;
+    private final Remark remark;
 
     // Data fields
     private final Address address;
@@ -28,18 +29,19 @@ public class Person {
     /**
      * Every field must be present and not null.
      */
-    public Person(String id, Name name, Phone phone, Email email, Address address, Set<Tag> tags) {
+    public Person(String id, Name name, Phone phone, Email email, Address address, Remark remark, Set<Tag> tags) {
         CollectionUtil.requireAllNonNull(name, phone, email, address, tags);
         this.id = id;
         this.name = name;
         this.phone = phone;
         this.email = email;
         this.address = address;
+        this.remark = remark;
         this.tags.addAll(tags);
     }
 
-    public Person(Name name, Phone phone, Email email, Address address, Set<Tag> tags) {
-        this(IdUtil.getId(), name, phone, email, address, tags);
+    public Person(Name name, Phone phone, Email email, Address address, Remark remark, Set<Tag> tags) {
+        this(IdUtil.getId(), name, phone, email, address, remark, tags);
     }
 
     public String getId() {
@@ -62,6 +64,10 @@ public class Person {
         return address;
     }
 
+    public Remark getRemark() {
+        return remark;
+    }
+
     /**
      * Returns an immutable tag set, which throws {@code UnsupportedOperationException} if modification is attempted.
      */
@@ -70,8 +76,8 @@ public class Person {
     }
 
     /**
-     * Returns true if both persons have the same name and phone number. This defines a notion of
-     * equality between two persons based on their identity.
+     * Returns true if both persons have the same name and phone number. This defines a notion of equality between two
+     * persons based on their identity.
      */
     public boolean isSamePerson(Person otherPerson) {
         if (otherPerson == this) {

--- a/src/main/java/spleetwaise/address/model/person/Remark.java
+++ b/src/main/java/spleetwaise/address/model/person/Remark.java
@@ -9,9 +9,8 @@ import spleetwaise.address.commons.util.AppUtil;
  * {@link #isValidRemark(String)}
  */
 public class Remark {
-    // Regex pattern to validate that the remark contains only alphanumeric characters and spaces, and does not start
-    // with a space. The regex match a string that starts with an alphanumeric character and is followed by zero or
-    // more alphanumeric characters or spaces
+    // Regex pattern to validate that the remark contains only [TBC]
+    // TODO: Update the regex pattern to match the requirements of the remark field
     public static final String VALIDATION_REGEX = "^[\\p{L}\\p{N}\\p{P}\\p{S}\\p{Zs}\\t]*$";
     public static final String MESSAGE_CONSTRAINTS = "Remarks should only contain alphanumeric characters and spaces";
     public final String value;

--- a/src/main/java/spleetwaise/address/model/person/Remark.java
+++ b/src/main/java/spleetwaise/address/model/person/Remark.java
@@ -2,10 +2,18 @@ package spleetwaise.address.model.person;
 
 import static java.util.Objects.requireNonNull;
 
+import spleetwaise.address.commons.util.AppUtil;
+
 /**
- * Represents a Person's remark in the address book. Guarantees: immutable; is always valid
+ * Represents a Person's remark in the address book. Guarantees: immutable; is valid as declared in
+ * {@link #isValidRemark(String)}
  */
 public class Remark {
+    // Regex pattern to validate that the remark contains only alphanumeric characters and spaces, and does not start
+    // with a space. The regex match a string that starts with an alphanumeric character and is followed by zero or
+    // more alphanumeric characters or spaces
+    public static final String VALIDATION_REGEX = "^[\\p{L}\\p{N}\\p{P}\\p{S}\\p{Zs}\\t]*$";
+    public static final String MESSAGE_CONSTRAINTS = "Remarks should only contain alphanumeric characters and spaces";
     public final String value;
 
     /**
@@ -13,7 +21,15 @@ public class Remark {
      */
     public Remark(String remark) {
         requireNonNull(remark);
+        AppUtil.checkArgument(isValidRemark(remark), MESSAGE_CONSTRAINTS);
         value = remark;
+    }
+
+    /**
+     * Returns true if a given string is a valid name.
+     */
+    public static boolean isValidRemark(String test) {
+        return test.matches(VALIDATION_REGEX);
     }
 
     @Override

--- a/src/main/java/spleetwaise/address/model/person/Remark.java
+++ b/src/main/java/spleetwaise/address/model/person/Remark.java
@@ -1,0 +1,35 @@
+package spleetwaise.address.model.person;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Represents a Person's remark in the address book. Guarantees: immutable; is always valid
+ */
+public class Remark {
+    public final String value;
+
+    /**
+     * Constructor for remark
+     */
+    public Remark(String remark) {
+        requireNonNull(remark);
+        value = remark;
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof Remark // instanceof handles nulls
+                && value.equals(((Remark) other).value)); // state check
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+}

--- a/src/main/java/spleetwaise/address/model/util/SampleDataUtil.java
+++ b/src/main/java/spleetwaise/address/model/util/SampleDataUtil.java
@@ -11,33 +11,30 @@ import spleetwaise.address.model.person.Email;
 import spleetwaise.address.model.person.Name;
 import spleetwaise.address.model.person.Person;
 import spleetwaise.address.model.person.Phone;
+import spleetwaise.address.model.person.Remark;
 import spleetwaise.address.model.tag.Tag;
 
 /**
  * Contains utility methods for populating {@code AddressBook} with sample data.
  */
 public class SampleDataUtil {
+    public static final Remark EMPTY_REMARK = new Remark("");
+
     public static Person[] getSamplePersons() {
-        return new Person[] {
-            new Person(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
-                new Address("Blk 30 Geylang Street 29, #06-40"),
-                getTagSet("friends")),
-            new Person(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
-                new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"),
-                getTagSet("colleagues", "friends")),
-            new Person(new Name("Charlotte Oliveiro"), new Phone("93210283"), new Email("charlotte@example.com"),
-                new Address("Blk 11 Ang Mo Kio Street 74, #11-04"),
-                getTagSet("neighbours")),
-            new Person(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
-                new Address("Blk 436 Serangoon Gardens Street 26, #16-43"),
-                getTagSet("family")),
-            new Person(new Name("Irfan Ibrahim"), new Phone("92492021"), new Email("irfan@example.com"),
-                new Address("Blk 47 Tampines Street 20, #17-35"),
-                getTagSet("classmates")),
-            new Person(new Name("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
-                new Address("Blk 45 Aljunied Street 85, #11-31"),
-                getTagSet("colleagues"))
-        };
+        return new Person[]{ new Person(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
+                new Address("Blk 30 Geylang Street 29, #06-40"), EMPTY_REMARK, getTagSet("friends")
+        ), new Person(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
+                new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"), EMPTY_REMARK,
+                getTagSet("colleagues", "friends")
+        ), new Person(new Name("Charlotte Oliveiro"), new Phone("93210283"), new Email("charlotte@example.com"),
+                new Address("Blk 11 Ang Mo Kio Street 74, #11-04"), EMPTY_REMARK, getTagSet("neighbours")
+        ), new Person(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
+                new Address("Blk 436 Serangoon Gardens Street 26, #16-43"), EMPTY_REMARK, getTagSet("family")
+        ), new Person(new Name("Irfan Ibrahim"), new Phone("92492021"), new Email("irfan@example.com"),
+                new Address("Blk 47 Tampines Street 20, #17-35"), EMPTY_REMARK, getTagSet("classmates")
+        ), new Person(new Name("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
+                new Address("Blk 45 Aljunied Street 85, #11-31"), EMPTY_REMARK, getTagSet("colleagues")
+        ) };
     }
 
     public static ReadOnlyAddressBook getSampleAddressBook() {
@@ -52,9 +49,7 @@ public class SampleDataUtil {
      * Returns a tag set containing the list of strings given.
      */
     public static Set<Tag> getTagSet(String... strings) {
-        return Arrays.stream(strings)
-                .map(Tag::new)
-                .collect(Collectors.toSet());
+        return Arrays.stream(strings).map(Tag::new).collect(Collectors.toSet());
     }
 
 }

--- a/src/main/java/spleetwaise/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/spleetwaise/address/storage/JsonAdaptedPerson.java
@@ -115,6 +115,9 @@ class JsonAdaptedPerson {
         if (remark == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Remark.class.getSimpleName()));
         }
+        if (!Remark.isValidRemark(remark)) {
+            throw new IllegalValueException(Remark.MESSAGE_CONSTRAINTS);
+        }
         final Remark modelRemark = new Remark(remark);
 
         final Set<Tag> modelTags = new HashSet<>(personTags);

--- a/src/main/java/spleetwaise/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/spleetwaise/address/storage/JsonAdaptedPerson.java
@@ -15,6 +15,7 @@ import spleetwaise.address.model.person.Email;
 import spleetwaise.address.model.person.Name;
 import spleetwaise.address.model.person.Person;
 import spleetwaise.address.model.person.Phone;
+import spleetwaise.address.model.person.Remark;
 import spleetwaise.address.model.tag.Tag;
 
 /**
@@ -29,21 +30,24 @@ class JsonAdaptedPerson {
     private final String phone;
     private final String email;
     private final String address;
+    private final String remark;
     private final List<JsonAdaptedTag> tags = new ArrayList<>();
 
     /**
      * Constructs a {@code JsonAdaptedPerson} with the given person details.
      */
     @JsonCreator
-    public JsonAdaptedPerson(@JsonProperty("id") String id, @JsonProperty("name") String name,
-        @JsonProperty("phone") String phone,
-        @JsonProperty("email") String email, @JsonProperty("address") String address,
-        @JsonProperty("tags") List<JsonAdaptedTag> tags) {
+    public JsonAdaptedPerson(
+            @JsonProperty("id") String id, @JsonProperty("name") String name, @JsonProperty("phone") String phone,
+            @JsonProperty("email") String email, @JsonProperty("address") String address,
+            @JsonProperty("remark") String remark, @JsonProperty("tags") List<JsonAdaptedTag> tags
+    ) {
         this.id = id;
         this.name = name;
         this.phone = phone;
         this.email = email;
         this.address = address;
+        this.remark = remark;
         if (tags != null) {
             this.tags.addAll(tags);
         }
@@ -58,9 +62,8 @@ class JsonAdaptedPerson {
         phone = source.getPhone().value;
         email = source.getEmail().value;
         address = source.getAddress().value;
-        tags.addAll(source.getTags().stream()
-            .map(JsonAdaptedTag::new)
-            .collect(Collectors.toList()));
+        remark = source.getRemark().value;
+        tags.addAll(source.getTags().stream().map(JsonAdaptedTag::new).collect(Collectors.toList()));
     }
 
     /**
@@ -109,8 +112,13 @@ class JsonAdaptedPerson {
         }
         final Address modelAddress = new Address(address);
 
+        if (remark == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Remark.class.getSimpleName()));
+        }
+        final Remark modelRemark = new Remark(remark);
+
         final Set<Tag> modelTags = new HashSet<>(personTags);
-        return new Person(id, modelName, modelPhone, modelEmail, modelAddress, modelTags);
+        return new Person(id, modelName, modelPhone, modelEmail, modelAddress, modelRemark, modelTags);
     }
 
 }

--- a/src/main/java/spleetwaise/address/ui/PersonCard.java
+++ b/src/main/java/spleetwaise/address/ui/PersonCard.java
@@ -39,6 +39,8 @@ public class PersonCard extends UiPart<Region> {
     @FXML
     private Label email;
     @FXML
+    private Label remark;
+    @FXML
     private FlowPane tags;
 
     /**
@@ -52,6 +54,7 @@ public class PersonCard extends UiPart<Region> {
         phone.setText(person.getPhone().value);
         address.setText(person.getAddress().value);
         email.setText(person.getEmail().value);
+        remark.setText(person.getRemark().value);
         person.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -31,6 +31,7 @@
       <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
       <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
       <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
+      <Label fx:id="remark" styleClass="cell_small_label" text="\$remark" />
     </VBox>
   </GridPane>
 </HBox>

--- a/src/test/data/JsonSerializableAddressBookTest/duplicateIdAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/duplicateIdAddressBook.json
@@ -5,12 +5,14 @@
     "phone": "94351253",
     "email": "alice@example.com",
     "address": "123, Jurong West Ave 6, #08-111",
+    "remark": "",
     "tags": [ "friends" ]
   }, {
     "id" : "29705d8f-6a2b-4de3-8b86-e8efb3f2215f",
     "name": "Alice Pauline2",
     "phone": "94351252",
     "email": "pauline2@example.com",
+    "remark": "",
     "address": "5th street"
   } ]
 }

--- a/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
@@ -5,12 +5,14 @@
     "phone": "94351253",
     "email": "alice@example.com",
     "address": "123, Jurong West Ave 6, #08-111",
+    "remark": "",
     "tags": [ "friends" ]
   }, {
     "id" : "3929a136-823a-4806-af62-e96b241167b5",
     "name": "Alice Pauline",
     "phone": "94351253",
     "email": "pauline@example.com",
+    "remark": "",
     "address": "4th street"
   } ]
 }

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -6,6 +6,7 @@
     "phone" : "94351253",
     "email" : "alice@example.com",
     "address" : "123, Jurong West Ave 6, #08-111",
+    "remark" : "alice is poor",
     "tags" : [ "friends" ]
   }, {
     "id" : "3929a136-823a-4806-af62-e96b241167b5",
@@ -13,6 +14,7 @@
     "phone" : "98765432",
     "email" : "johnd@example.com",
     "address" : "311, Clementi Ave 2, #02-25",
+    "remark" : "benson is rich",
     "tags" : [ "owesMoney", "friends" ]
   }, {
     "id" : "60196500-3d01-4e6c-81de-44ab6fc9e7e5",
@@ -20,6 +22,7 @@
     "phone" : "95352563",
     "email" : "heinz@example.com",
     "address" : "wall street",
+    "remark" : "",
     "tags" : [ ]
   }, {
     "id" : "b89d7c94-9823-4b6a-ae46-b7c55ee41727",
@@ -27,6 +30,7 @@
     "phone" : "87652533",
     "email" : "cornelia@example.com",
     "address" : "10th street",
+    "remark" : "DANIEL IS IN DEBT",
     "tags" : [ "friends" ]
   }, {
     "id" : "42984eac-421f-4966-994d-6f360d7d2882",
@@ -34,6 +38,7 @@
     "phone" : "9482224",
     "email" : "werner@example.com",
     "address" : "michegan ave",
+    "remark" : "",
     "tags" : [ ]
   }, {
     "id" : "c5a93d37-44fd-4f4d-964b-6f85c715d6e3",
@@ -41,6 +46,7 @@
     "phone" : "9482427",
     "email" : "lydia@example.com",
     "address" : "little tokyo",
+    "remark" : "",
     "tags" : [ ]
   }, {
     "id" : "c5a93d37-44fd-4f4d-964b-6f85c715djf93",
@@ -48,6 +54,7 @@
     "phone" : "9482442",
     "email" : "anna@example.com",
     "address" : "4th street",
+    "remark" : "",
     "tags" : [ ]
   } ]
 }

--- a/src/test/java/spleetwaise/address/logic/LogicManagerTest.java
+++ b/src/test/java/spleetwaise/address/logic/LogicManagerTest.java
@@ -43,8 +43,8 @@ public class LogicManagerTest {
 
     @BeforeEach
     public void setUp() {
-        JsonAddressBookStorage addressBookStorage =
-            new JsonAddressBookStorage(temporaryFolder.resolve("addressBook.json"));
+        JsonAddressBookStorage addressBookStorage = new JsonAddressBookStorage(
+                temporaryFolder.resolve("addressBook.json"));
         JsonUserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(temporaryFolder.resolve("userPrefs.json"));
         StorageManager storage = new StorageManager(addressBookStorage, userPrefsStorage);
         logic = new LogicManager(addressBookModel, transactionModel, storage);
@@ -94,8 +94,10 @@ public class LogicManagerTest {
 
         // TODO: add a TransactionUtil class to handle generation of commands and expected messages
         String addTxnCommand = "addTxn p/94351253 amt/+12.3 desc/Test date/01012024";
-        String expectedMessageSuccess = String.format(spleetwaise.transaction.logic.commands.AddCommand.MESSAGE_SUCCESS,
-            "[test-uuid] Alice Pauline(94351253): Test on 01/01/2024 for $+12.30");
+        String expectedMessageSuccess = String.format(
+                spleetwaise.transaction.logic.commands.AddCommand.MESSAGE_SUCCESS,
+                "[test-uuid] Alice Pauline(94351253): Test on 01/01/2024 for $+12.30"
+        );
 
         assertCommandSuccess(listCommand, ListCommand.MESSAGE_SUCCESS, addressBookModel, transactionModel);
         IdUtil.setDeterminate(true);
@@ -106,15 +108,15 @@ public class LogicManagerTest {
     @Test
     public void execute_storageThrowsIoException_throwsCommandException() {
         assertCommandFailureForExceptionFromStorage(DUMMY_IO_EXCEPTION,
-            String.format(LogicManager.FILE_OPS_ERROR_FORMAT,
-                DUMMY_IO_EXCEPTION.getMessage()));
+                String.format(LogicManager.FILE_OPS_ERROR_FORMAT, DUMMY_IO_EXCEPTION.getMessage())
+        );
     }
 
     @Test
     public void execute_storageThrowsAdException_throwsCommandException() {
         assertCommandFailureForExceptionFromStorage(DUMMY_AD_EXCEPTION,
-            String.format(LogicManager.FILE_OPS_PERMISSION_ERROR_FORMAT,
-                DUMMY_AD_EXCEPTION.getMessage()));
+                String.format(LogicManager.FILE_OPS_PERMISSION_ERROR_FORMAT, DUMMY_AD_EXCEPTION.getMessage())
+        );
     }
 
     @Test
@@ -130,10 +132,10 @@ public class LogicManagerTest {
      * @see #assertCommandFailure(String, Class, String, spleetwaise.address.model.Model,
      * spleetwaise.transaction.model.Model)
      */
-    private void assertCommandSuccess(String inputCommand, String expectedMessage,
-        spleetwaise.address.model.Model expectedAddressBookModel,
-        spleetwaise.transaction.model.Model expectedTransactionModel)
-            throws SpleetWaiseCommandException, ParseException {
+    private void assertCommandSuccess(
+            String inputCommand, String expectedMessage, spleetwaise.address.model.Model expectedAddressBookModel,
+            spleetwaise.transaction.model.Model expectedTransactionModel
+    ) throws SpleetWaiseCommandException, ParseException {
         CommandResult result = logic.execute(inputCommand);
         assertEquals(expectedMessage, result.getFeedbackToUser());
         assertEquals(expectedAddressBookModel, addressBookModel);
@@ -166,14 +168,16 @@ public class LogicManagerTest {
      * @see #assertCommandFailure(String, Class, String, spleetwaise.address.model.Model,
      * spleetwaise.transaction.model.Model)
      */
-    private void assertCommandFailure(String inputCommand, Class<? extends Throwable> expectedException,
-        String expectedMessage) {
-        spleetwaise.address.model.Model expectedAddressBookModel =
-            new spleetwaise.address.model.ModelManager(addressBookModel.getAddressBook(), new UserPrefs());
+    private void assertCommandFailure(
+            String inputCommand, Class<? extends Throwable> expectedException, String expectedMessage
+    ) {
+        spleetwaise.address.model.Model expectedAddressBookModel = new spleetwaise.address.model.ModelManager(
+                addressBookModel.getAddressBook(), new UserPrefs());
 
         spleetwaise.transaction.model.Model expectedTransactionModel = new spleetwaise.transaction.model.ModelManager();
         assertCommandFailure(inputCommand, expectedException, expectedMessage, expectedAddressBookModel,
-            expectedTransactionModel);
+                expectedTransactionModel
+        );
     }
 
     /**
@@ -183,9 +187,11 @@ public class LogicManagerTest {
      *
      * @see #assertCommandSuccess(String, String, spleetwaise.address.model.Model, spleetwaise.transaction.model.Model)
      */
-    private void assertCommandFailure(String inputCommand, Class<? extends Throwable> expectedException,
-        String expectedMessage, spleetwaise.address.model.Model expectedAddressBookModel,
-        spleetwaise.transaction.model.Model expectedTransactionModel) {
+    private void assertCommandFailure(
+            String inputCommand, Class<? extends Throwable> expectedException, String expectedMessage,
+            spleetwaise.address.model.Model expectedAddressBookModel,
+            spleetwaise.transaction.model.Model expectedTransactionModel
+    ) {
         Assert.assertThrows(expectedException, expectedMessage, () -> logic.execute(inputCommand));
         assertEquals(expectedAddressBookModel, addressBookModel);
         assertEquals(expectedTransactionModel, transactionModel);
@@ -208,15 +214,15 @@ public class LogicManagerTest {
             }
         };
 
-        JsonUserPrefsStorage userPrefsStorage =
-            new JsonUserPrefsStorage(temporaryFolder.resolve("ExceptionUserPrefs.json"));
+        JsonUserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(
+                temporaryFolder.resolve("ExceptionUserPrefs.json"));
         StorageManager storage = new StorageManager(addressBookStorage, userPrefsStorage);
 
         logic = new LogicManager(addressBookModel, transactionModel, storage);
 
         // Triggers the saveAddressBook method by executing an add command
         String addCommand = AddCommand.COMMAND_WORD + CommandTestUtil.NAME_DESC_AMY + CommandTestUtil.PHONE_DESC_AMY
-            + CommandTestUtil.EMAIL_DESC_AMY + CommandTestUtil.ADDRESS_DESC_AMY;
+                + CommandTestUtil.EMAIL_DESC_AMY + CommandTestUtil.ADDRESS_DESC_AMY + CommandTestUtil.REMARK_DESC_AMY;
 
         IdUtil.setDeterminate(true);
         Person expectedPerson = new PersonBuilder(TypicalPersons.AMY).withId(IdUtil.getId()).withTags().build();
@@ -227,7 +233,8 @@ public class LogicManagerTest {
         spleetwaise.transaction.model.Model expectedTransactionModel = new spleetwaise.transaction.model.ModelManager();
 
         assertCommandFailure(addCommand, CommandException.class, expectedMessage, expectedAddressBookModel,
-            expectedTransactionModel);
+                expectedTransactionModel
+        );
         IdUtil.setDeterminate(false);
     }
 }

--- a/src/test/java/spleetwaise/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/spleetwaise/address/logic/commands/CommandTestUtil.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import spleetwaise.address.commons.core.index.Index;
@@ -32,6 +32,8 @@ public class CommandTestUtil {
     public static final String VALID_EMAIL_BOB = "bob@example.com";
     public static final String VALID_ADDRESS_AMY = "Block 312, Amy Street 1";
     public static final String VALID_ADDRESS_BOB = "Block 123, Bobby Street 3";
+    public static final String VALID_REMARK_AMY = "AMY IS RICH";
+    public static final String VALID_REMARK_BOB = "BOB IS POOR";
     public static final String VALID_TAG_HUSBAND = "husband";
     public static final String VALID_TAG_FRIEND = "friend";
 
@@ -43,6 +45,8 @@ public class CommandTestUtil {
     public static final String EMAIL_DESC_BOB = " " + CliSyntax.PREFIX_EMAIL + VALID_EMAIL_BOB;
     public static final String ADDRESS_DESC_AMY = " " + CliSyntax.PREFIX_ADDRESS + VALID_ADDRESS_AMY;
     public static final String ADDRESS_DESC_BOB = " " + CliSyntax.PREFIX_ADDRESS + VALID_ADDRESS_BOB;
+    public static final String REMARK_DESC_AMY = " " + CliSyntax.PREFIX_REMARK + VALID_REMARK_AMY;
+    public static final String REMARK_DESC_BOB = " " + CliSyntax.PREFIX_REMARK + VALID_REMARK_BOB;
     public static final String TAG_DESC_FRIEND = " " + CliSyntax.PREFIX_TAG + VALID_TAG_FRIEND;
     public static final String TAG_DESC_HUSBAND = " " + CliSyntax.PREFIX_TAG + VALID_TAG_HUSBAND;
 
@@ -62,19 +66,21 @@ public class CommandTestUtil {
 
     static {
         DESC_AMY = new EditPersonDescriptorBuilder().withName(VALID_NAME_AMY)
-            .withPhone(VALID_PHONE_AMY).withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY)
-            .withTags(VALID_TAG_FRIEND).build();
+                .withPhone(VALID_PHONE_AMY).withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY)
+                .withRemark(VALID_REMARK_AMY).withTags(VALID_TAG_FRIEND).build();
         DESC_BOB = new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB)
-            .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB)
-            .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
+                .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB)
+                .withRemark(VALID_REMARK_BOB).withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
     }
 
     /**
      * Executes the given {@code command}, confirms that <br> - the returned {@link CommandResult} matches
      * {@code expectedCommandResult} <br> - the {@code actualModel} matches {@code expectedModel}
      */
-    public static void assertCommandSuccess(Command command, Model actualModel, CommandResult expectedCommandResult,
-        Model expectedModel) {
+    public static void assertCommandSuccess(
+            Command command, Model actualModel, CommandResult expectedCommandResult,
+            Model expectedModel
+    ) {
         try {
             CommandResult result = command.execute(actualModel);
             assertEquals(expectedCommandResult, result);
@@ -88,8 +94,10 @@ public class CommandTestUtil {
      * Convenience wrapper to {@link #assertCommandSuccess(Command, Model, CommandResult, Model)} that takes a string
      * {@code expectedMessage}.
      */
-    public static void assertCommandSuccess(Command command, Model actualModel, String expectedMessage,
-        Model expectedModel) {
+    public static void assertCommandSuccess(
+            Command command, Model actualModel, String expectedMessage,
+            Model expectedModel
+    ) {
         CommandResult expectedCommandResult = new CommandResult(expectedMessage);
         assertCommandSuccess(command, actualModel, expectedCommandResult, expectedModel);
     }
@@ -119,7 +127,7 @@ public class CommandTestUtil {
 
         Person person = model.getFilteredPersonList().get(targetIndex.getZeroBased());
         final String[] splitName = person.getName().fullName.split("\\s+");
-        model.updateFilteredPersonList(new NameContainsKeywordsPredicate(Arrays.asList(splitName[0])));
+        model.updateFilteredPersonList(new NameContainsKeywordsPredicate(Collections.singletonList(splitName[0])));
 
         assertEquals(1, model.getFilteredPersonList().size());
     }

--- a/src/test/java/spleetwaise/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/spleetwaise/address/logic/commands/EditCommandTest.java
@@ -1,7 +1,7 @@
 package spleetwaise.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
@@ -24,7 +24,7 @@ import spleetwaise.address.testutil.TypicalPersons;
  */
 public class EditCommandTest {
 
-    private Model model = new ModelManager(TypicalPersons.getTypicalAddressBook(), new UserPrefs());
+    private final Model model = new ModelManager(TypicalPersons.getTypicalAddressBook(), new UserPrefs());
 
     @Test
     public void execute_allFieldsSpecifiedUnfilteredList_success() {
@@ -47,11 +47,13 @@ public class EditCommandTest {
 
         PersonBuilder personInList = new PersonBuilder(lastPerson);
         Person editedPerson =
-            personInList.withName(CommandTestUtil.VALID_NAME_BOB).withPhone(CommandTestUtil.VALID_PHONE_BOB)
-                .withTags(CommandTestUtil.VALID_TAG_HUSBAND).build();
+                personInList.withName(CommandTestUtil.VALID_NAME_BOB).withPhone(CommandTestUtil.VALID_PHONE_BOB)
+                        .withRemark(CommandTestUtil.VALID_REMARK_BOB).withTags(CommandTestUtil.VALID_TAG_HUSBAND)
+                        .build();
 
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withName(CommandTestUtil.VALID_NAME_BOB)
-            .withPhone(CommandTestUtil.VALID_PHONE_BOB).withTags(CommandTestUtil.VALID_TAG_HUSBAND).build();
+                .withPhone(CommandTestUtil.VALID_PHONE_BOB).withRemark(CommandTestUtil.VALID_REMARK_BOB)
+                .withTags(CommandTestUtil.VALID_TAG_HUSBAND).build();
         EditCommand editCommand = new EditCommand(indexLastPerson, descriptor);
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
@@ -79,10 +81,12 @@ public class EditCommandTest {
         CommandTestUtil.showPersonAtIndex(model, TypicalIndexes.INDEX_FIRST_PERSON);
 
         Person personInFilteredList =
-            model.getFilteredPersonList().get(TypicalIndexes.INDEX_FIRST_PERSON.getZeroBased());
+                model.getFilteredPersonList().get(TypicalIndexes.INDEX_FIRST_PERSON.getZeroBased());
         Person editedPerson = new PersonBuilder(personInFilteredList).withName(CommandTestUtil.VALID_NAME_BOB).build();
-        EditCommand editCommand = new EditCommand(TypicalIndexes.INDEX_FIRST_PERSON,
-            new EditPersonDescriptorBuilder().withName(CommandTestUtil.VALID_NAME_BOB).build());
+        EditCommand editCommand = new EditCommand(
+                TypicalIndexes.INDEX_FIRST_PERSON,
+                new EditPersonDescriptorBuilder().withName(CommandTestUtil.VALID_NAME_BOB).build()
+        );
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
 
@@ -107,9 +111,10 @@ public class EditCommandTest {
 
         // edit person in filtered list into a duplicate in address book
         Person personInList =
-            model.getAddressBook().getPersonList().get(TypicalIndexes.INDEX_SECOND_PERSON.getZeroBased());
+                model.getAddressBook().getPersonList().get(TypicalIndexes.INDEX_SECOND_PERSON.getZeroBased());
         EditCommand editCommand =
-            new EditCommand(TypicalIndexes.INDEX_FIRST_PERSON, new EditPersonDescriptorBuilder(personInList).build());
+                new EditCommand(
+                        TypicalIndexes.INDEX_FIRST_PERSON, new EditPersonDescriptorBuilder(personInList).build());
 
         CommandTestUtil.assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_PERSON);
     }
@@ -118,7 +123,7 @@ public class EditCommandTest {
     public void execute_invalidPersonIndexUnfilteredList_failure() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
         EditPersonDescriptor descriptor =
-            new EditPersonDescriptorBuilder().withName(CommandTestUtil.VALID_NAME_BOB).build();
+                new EditPersonDescriptorBuilder().withName(CommandTestUtil.VALID_NAME_BOB).build();
         EditCommand editCommand = new EditCommand(outOfBoundIndex, descriptor);
 
         CommandTestUtil.assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
@@ -134,8 +139,10 @@ public class EditCommandTest {
         // ensures that outOfBoundIndex is still in bounds of address book list
         assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
 
-        EditCommand editCommand = new EditCommand(outOfBoundIndex,
-            new EditPersonDescriptorBuilder().withName(CommandTestUtil.VALID_NAME_BOB).build());
+        EditCommand editCommand = new EditCommand(
+                outOfBoundIndex,
+                new EditPersonDescriptorBuilder().withName(CommandTestUtil.VALID_NAME_BOB).build()
+        );
 
         CommandTestUtil.assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
@@ -143,29 +150,27 @@ public class EditCommandTest {
     @Test
     public void equals() {
         final EditCommand standardCommand =
-            new EditCommand(TypicalIndexes.INDEX_FIRST_PERSON, CommandTestUtil.DESC_AMY);
+                new EditCommand(TypicalIndexes.INDEX_FIRST_PERSON, CommandTestUtil.DESC_AMY);
 
         // same values -> returns true
         EditPersonDescriptor copyDescriptor = new EditPersonDescriptor(CommandTestUtil.DESC_AMY);
         EditCommand commandWithSameValues = new EditCommand(TypicalIndexes.INDEX_FIRST_PERSON, copyDescriptor);
-        assertTrue(standardCommand.equals(commandWithSameValues));
+        assertEquals(standardCommand, commandWithSameValues);
 
         // same object -> returns true
-        assertTrue(standardCommand.equals(standardCommand));
+        assertEquals(standardCommand, standardCommand);
 
         // null -> returns false
-        assertFalse(standardCommand.equals(null));
+        assertNotEquals(null, standardCommand);
 
         // different types -> returns false
-        assertFalse(standardCommand.equals(new ClearCommand()));
+        assertNotEquals(standardCommand, new ClearCommand());
 
         // different index -> returns false
-        assertFalse(
-            standardCommand.equals(new EditCommand(TypicalIndexes.INDEX_SECOND_PERSON, CommandTestUtil.DESC_AMY)));
+        assertNotEquals(standardCommand, new EditCommand(TypicalIndexes.INDEX_SECOND_PERSON, CommandTestUtil.DESC_AMY));
 
         // different descriptor -> returns false
-        assertFalse(
-            standardCommand.equals(new EditCommand(TypicalIndexes.INDEX_FIRST_PERSON, CommandTestUtil.DESC_BOB)));
+        assertNotEquals(standardCommand, new EditCommand(TypicalIndexes.INDEX_FIRST_PERSON, CommandTestUtil.DESC_BOB));
     }
 
     @Test
@@ -174,8 +179,9 @@ public class EditCommandTest {
         EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();
         EditCommand editCommand = new EditCommand(index, editPersonDescriptor);
         String expected =
-            EditCommand.class.getCanonicalName() + "{index=" + index + ", editPersonDescriptor=" + editPersonDescriptor
-                + "}";
+                EditCommand.class.getCanonicalName() + "{index=" + index + ", editPersonDescriptor="
+                        + editPersonDescriptor
+                        + "}";
         assertEquals(expected, editCommand.toString());
     }
 

--- a/src/test/java/spleetwaise/address/logic/commands/EditPersonDescriptorTest.java
+++ b/src/test/java/spleetwaise/address/logic/commands/EditPersonDescriptorTest.java
@@ -14,56 +14,57 @@ public class EditPersonDescriptorTest {
     public void equals() {
         // same values -> returns true
         EditPersonDescriptor descriptorWithSameValues = new EditPersonDescriptor(CommandTestUtil.DESC_AMY);
-        Assertions.assertTrue(CommandTestUtil.DESC_AMY.equals(descriptorWithSameValues));
+        assertEquals(CommandTestUtil.DESC_AMY, descriptorWithSameValues);
 
         // same object -> returns true
-        Assertions.assertTrue(CommandTestUtil.DESC_AMY.equals(CommandTestUtil.DESC_AMY));
+        assertEquals(CommandTestUtil.DESC_AMY, CommandTestUtil.DESC_AMY);
 
         // null -> returns false
-        Assertions.assertFalse(CommandTestUtil.DESC_AMY.equals(null));
+        Assertions.assertNotEquals(null, CommandTestUtil.DESC_AMY);
 
         // different types -> returns false
-        Assertions.assertFalse(CommandTestUtil.DESC_AMY.equals(5));
+        Assertions.assertNotEquals(5, CommandTestUtil.DESC_AMY);
 
         // different values -> returns false
-        Assertions.assertFalse(CommandTestUtil.DESC_AMY.equals(CommandTestUtil.DESC_BOB));
+        Assertions.assertNotEquals(CommandTestUtil.DESC_AMY, CommandTestUtil.DESC_BOB);
 
         // different name -> returns false
         EditPersonDescriptor editedAmy = new EditPersonDescriptorBuilder(CommandTestUtil.DESC_AMY).withName(
-            CommandTestUtil.VALID_NAME_BOB).build();
-        Assertions.assertFalse(CommandTestUtil.DESC_AMY.equals(editedAmy));
+                CommandTestUtil.VALID_NAME_BOB).build();
+        Assertions.assertNotEquals(CommandTestUtil.DESC_AMY, editedAmy);
 
         // different phone -> returns false
         editedAmy = new EditPersonDescriptorBuilder(CommandTestUtil.DESC_AMY).withPhone(CommandTestUtil.VALID_PHONE_BOB)
-            .build();
-        Assertions.assertFalse(CommandTestUtil.DESC_AMY.equals(editedAmy));
+                .build();
+        Assertions.assertNotEquals(CommandTestUtil.DESC_AMY, editedAmy);
 
         // different email -> returns false
         editedAmy = new EditPersonDescriptorBuilder(CommandTestUtil.DESC_AMY).withEmail(CommandTestUtil.VALID_EMAIL_BOB)
-            .build();
-        Assertions.assertFalse(CommandTestUtil.DESC_AMY.equals(editedAmy));
+                .build();
+        Assertions.assertNotEquals(CommandTestUtil.DESC_AMY, editedAmy);
 
         // different address -> returns false
         editedAmy = new EditPersonDescriptorBuilder(CommandTestUtil.DESC_AMY).withAddress(
-            CommandTestUtil.VALID_ADDRESS_BOB).build();
-        Assertions.assertFalse(CommandTestUtil.DESC_AMY.equals(editedAmy));
+                CommandTestUtil.VALID_ADDRESS_BOB).build();
+        Assertions.assertNotEquals(CommandTestUtil.DESC_AMY, editedAmy);
 
         // different tags -> returns false
         editedAmy =
-            new EditPersonDescriptorBuilder(CommandTestUtil.DESC_AMY).withTags(CommandTestUtil.VALID_TAG_HUSBAND)
-                .build();
-        Assertions.assertFalse(CommandTestUtil.DESC_AMY.equals(editedAmy));
+                new EditPersonDescriptorBuilder(CommandTestUtil.DESC_AMY).withTags(CommandTestUtil.VALID_TAG_HUSBAND)
+                        .build();
+        Assertions.assertNotEquals(CommandTestUtil.DESC_AMY, editedAmy);
     }
 
     @Test
     public void toStringMethod() {
         EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();
         String expected = EditPersonDescriptor.class.getCanonicalName() + "{name="
-            + editPersonDescriptor.getName().orElse(null) + ", phone="
-            + editPersonDescriptor.getPhone().orElse(null) + ", email="
-            + editPersonDescriptor.getEmail().orElse(null) + ", address="
-            + editPersonDescriptor.getAddress().orElse(null) + ", tags="
-            + editPersonDescriptor.getTags().orElse(null) + "}";
+                + editPersonDescriptor.getName().orElse(null) + ", phone="
+                + editPersonDescriptor.getPhone().orElse(null) + ", email="
+                + editPersonDescriptor.getEmail().orElse(null) + ", address="
+                + editPersonDescriptor.getAddress().orElse(null) + ", remark="
+                + editPersonDescriptor.getRemark().orElse(null) + ", tags="
+                + editPersonDescriptor.getTags().orElse(null) + "}";
         assertEquals(expected, editPersonDescriptor.toString());
     }
 }

--- a/src/test/java/spleetwaise/address/logic/commands/RemarkCommandTest.java
+++ b/src/test/java/spleetwaise/address/logic/commands/RemarkCommandTest.java
@@ -1,0 +1,135 @@
+package spleetwaise.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static spleetwaise.address.logic.commands.CommandTestUtil.VALID_REMARK_AMY;
+import static spleetwaise.address.logic.commands.CommandTestUtil.VALID_REMARK_BOB;
+import static spleetwaise.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static spleetwaise.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static spleetwaise.address.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static spleetwaise.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static spleetwaise.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static spleetwaise.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.Test;
+
+import spleetwaise.address.commons.core.index.Index;
+import spleetwaise.address.logic.Messages;
+import spleetwaise.address.model.AddressBook;
+import spleetwaise.address.model.Model;
+import spleetwaise.address.model.ModelManager;
+import spleetwaise.address.model.UserPrefs;
+import spleetwaise.address.model.person.Person;
+import spleetwaise.address.model.person.Remark;
+import spleetwaise.address.testutil.PersonBuilder;
+import spleetwaise.commons.IdUtil;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for RemarkCommand.
+ */
+public class RemarkCommandTest {
+
+    private static final String REMARK_STUB = "Some remark";
+
+    private final Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute_addRemarkUnfilteredList_success() {
+        IdUtil.setDeterminate(true);
+        Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person editedPerson = new PersonBuilder(firstPerson).withRemark(REMARK_STUB).build();
+
+        RemarkCommand remarkCommand = new RemarkCommand(INDEX_FIRST_PERSON, new Remark(editedPerson.getRemark().value));
+
+        String expectedMessage = String.format(RemarkCommand.MESSAGE_ADD_REMARK_SUCCESS, editedPerson);
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setPerson(firstPerson, editedPerson);
+
+        assertCommandSuccess(remarkCommand, model, expectedMessage, expectedModel);
+        IdUtil.setDeterminate(false);
+    }
+
+    @Test
+    public void execute_deleteRemarkUnfilteredList_success() {
+        Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person editedPerson = new PersonBuilder(firstPerson).withRemark("").build();
+
+        RemarkCommand remarkCommand =
+                new RemarkCommand(INDEX_FIRST_PERSON, new Remark(editedPerson.getRemark().toString()));
+
+        String expectedMessage = String.format(RemarkCommand.MESSAGE_DELETE_REMARK_SUCCESS, editedPerson);
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setPerson(firstPerson, editedPerson);
+
+        assertCommandSuccess(remarkCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_filteredList_success() {
+        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+
+        Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person editedPerson =
+                new PersonBuilder(model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased())).withRemark(
+                        REMARK_STUB).build();
+
+        RemarkCommand remarkCommand = new RemarkCommand(INDEX_FIRST_PERSON, new Remark(editedPerson.getRemark().value));
+
+        String expectedMessage = String.format(RemarkCommand.MESSAGE_ADD_REMARK_SUCCESS, editedPerson);
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setPerson(firstPerson, editedPerson);
+
+        assertCommandSuccess(remarkCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidPersonIndexUnfilteredList_failure() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+        RemarkCommand remarkCommand = new RemarkCommand(outOfBoundIndex, new Remark(VALID_REMARK_BOB));
+
+        assertCommandFailure(remarkCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    /**
+     * Edit filtered list where index is larger than size of filtered list, but smaller than size of address book
+     */
+    @Test
+    public void execute_invalidPersonIndexFilteredList_failure() {
+        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+        Index outOfBoundIndex = INDEX_SECOND_PERSON;
+        // ensures that outOfBoundIndex is still in bounds of address book list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
+
+        RemarkCommand remarkCommand = new RemarkCommand(outOfBoundIndex, new Remark(VALID_REMARK_BOB));
+
+        assertCommandFailure(remarkCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        final RemarkCommand standardCommand = new RemarkCommand(INDEX_FIRST_PERSON, new Remark(VALID_REMARK_AMY));
+
+        // same values -> returns true
+        RemarkCommand commandWithSameValues = new RemarkCommand(INDEX_FIRST_PERSON, new Remark(VALID_REMARK_AMY));
+        assertEquals(standardCommand, commandWithSameValues);
+
+        // same object -> returns true
+        assertEquals(standardCommand, standardCommand);
+
+        // null -> returns false
+        assertNotEquals(null, standardCommand);
+
+        // different types -> returns false
+        assertNotEquals(standardCommand, new ClearCommand());
+
+        // different index -> returns false
+        assertNotEquals(standardCommand, new RemarkCommand(INDEX_SECOND_PERSON, new Remark(VALID_REMARK_AMY)));
+
+        // different remark -> returns false
+        assertNotEquals(standardCommand, new RemarkCommand(INDEX_FIRST_PERSON, new Remark(VALID_REMARK_BOB)));
+    }
+}

--- a/src/test/java/spleetwaise/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/spleetwaise/address/logic/parser/AddressBookParserTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static spleetwaise.address.logic.parser.CliSyntax.PREFIX_REMARK;
+import static spleetwaise.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
 import java.util.Arrays;
 import java.util.List;
@@ -20,13 +22,14 @@ import spleetwaise.address.logic.commands.ExitCommand;
 import spleetwaise.address.logic.commands.FindCommand;
 import spleetwaise.address.logic.commands.HelpCommand;
 import spleetwaise.address.logic.commands.ListCommand;
+import spleetwaise.address.logic.commands.RemarkCommand;
 import spleetwaise.address.logic.parser.exceptions.ParseException;
 import spleetwaise.address.model.person.NameContainsKeywordsPredicate;
 import spleetwaise.address.model.person.Person;
+import spleetwaise.address.model.person.Remark;
 import spleetwaise.address.testutil.EditPersonDescriptorBuilder;
 import spleetwaise.address.testutil.PersonBuilder;
 import spleetwaise.address.testutil.PersonUtil;
-import spleetwaise.address.testutil.TypicalIndexes;
 
 public class AddressBookParserTest {
 
@@ -48,8 +51,8 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_delete() throws Exception {
         DeleteCommand command = (DeleteCommand) parser.parseCommand(
-                DeleteCommand.COMMAND_WORD + " " + TypicalIndexes.INDEX_FIRST_PERSON.getOneBased());
-        assertEquals(new DeleteCommand(TypicalIndexes.INDEX_FIRST_PERSON), command);
+                DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased());
+        assertEquals(new DeleteCommand(INDEX_FIRST_PERSON), command);
     }
 
     @Test
@@ -57,7 +60,7 @@ public class AddressBookParserTest {
         Person person = new PersonBuilder().build();
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(person).build();
         EditCommand command = (EditCommand) parser.parseCommand(EditCommand.COMMAND_WORD + " "
-                + TypicalIndexes.INDEX_FIRST_PERSON.getOneBased() + " " + PersonUtil.getEditPersonDescriptorDetails(
+                + INDEX_FIRST_PERSON.getOneBased() + " " + PersonUtil.getEditPersonDescriptorDetails(
                 descriptor));
 
         // TODO: Fix this test
@@ -89,6 +92,15 @@ public class AddressBookParserTest {
     public void parseCommand_list() throws Exception {
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD) instanceof ListCommand);
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3") instanceof ListCommand);
+    }
+
+    @Test
+    public void parseCommand_remark() throws Exception {
+        final Remark remark = new Remark("Some remark");
+        RemarkCommand command = (RemarkCommand) parser.parseCommand(
+                RemarkCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased() + " " + PREFIX_REMARK
+                        + remark.value);
+        assertEquals(new RemarkCommand(INDEX_FIRST_PERSON, remark), command);
     }
 
     @Test

--- a/src/test/java/spleetwaise/address/logic/parser/RemarkCommandParserTest.java
+++ b/src/test/java/spleetwaise/address/logic/parser/RemarkCommandParserTest.java
@@ -1,0 +1,43 @@
+package spleetwaise.address.logic.parser;
+
+import static spleetwaise.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static spleetwaise.address.logic.parser.CliSyntax.PREFIX_REMARK;
+import static spleetwaise.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static spleetwaise.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static spleetwaise.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+
+import org.junit.jupiter.api.Test;
+
+import spleetwaise.address.commons.core.index.Index;
+import spleetwaise.address.logic.commands.RemarkCommand;
+import spleetwaise.address.model.person.Remark;
+
+public class RemarkCommandParserTest {
+    private final Remark nonEmptyRemark = new Remark("remark");
+    private final RemarkCommandParser parser = new RemarkCommandParser();
+
+    @Test
+    public void parse_indexSpecified_success() {
+        // have remark
+        Index targetIndex = INDEX_FIRST_PERSON;
+        String userInput = targetIndex.getOneBased() + " " + PREFIX_REMARK + nonEmptyRemark;
+        RemarkCommand expectedCommand = new RemarkCommand(INDEX_FIRST_PERSON, nonEmptyRemark);
+        assertParseSuccess(parser, userInput, expectedCommand);
+
+        // no remark
+        userInput = targetIndex.getOneBased() + " " + PREFIX_REMARK;
+        expectedCommand = new RemarkCommand(INDEX_FIRST_PERSON, new Remark(""));
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_missingCompulsoryField_failure() {
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, RemarkCommand.MESSAGE_USAGE);
+
+        // no parameters
+        assertParseFailure(parser, RemarkCommand.COMMAND_WORD, expectedMessage);
+
+        // no index
+        assertParseFailure(parser, RemarkCommand.COMMAND_WORD + " " + nonEmptyRemark, expectedMessage);
+    }
+}

--- a/src/test/java/spleetwaise/address/model/person/PersonTest.java
+++ b/src/test/java/spleetwaise/address/model/person/PersonTest.java
@@ -8,6 +8,7 @@ import static spleetwaise.address.logic.commands.CommandTestUtil.VALID_ADDRESS_B
 import static spleetwaise.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
 import static spleetwaise.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static spleetwaise.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
+import static spleetwaise.address.logic.commands.CommandTestUtil.VALID_REMARK_BOB;
 import static spleetwaise.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 
 import java.util.HashSet;
@@ -40,7 +41,8 @@ public class PersonTest {
 
         Person editedAlice =
                 new PersonBuilder(TypicalPersons.ALICE).withId(TypicalPersons.ALICE.getId()).withPhone(VALID_PHONE_BOB)
-                        .withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND).build();
+                        .withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB).withRemark(VALID_REMARK_BOB)
+                        .withTags(VALID_TAG_HUSBAND).build();
         assertTrue(TypicalPersons.ALICE.hasSameId(editedAlice));
         // Even though isSamePerson returns false, hasSameId returns true. This is to facilitate the editing of
         // the person's details without changing the id
@@ -133,6 +135,7 @@ public class PersonTest {
         String expected = Person.class.getCanonicalName() + "{name=" + TypicalPersons.ALICE.getName() + ", phone="
                 + TypicalPersons.ALICE.getPhone()
                 + ", email=" + TypicalPersons.ALICE.getEmail() + ", address=" + TypicalPersons.ALICE.getAddress()
+                + ", remark=" + TypicalPersons.ALICE.getRemark()
                 + ", tags=" + TypicalPersons.ALICE.getTags() + "}";
         assertEquals(expected, TypicalPersons.ALICE.toString());
     }

--- a/src/test/java/spleetwaise/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/spleetwaise/address/storage/JsonAdaptedPersonTest.java
@@ -14,6 +14,7 @@ import spleetwaise.address.model.person.Address;
 import spleetwaise.address.model.person.Email;
 import spleetwaise.address.model.person.Name;
 import spleetwaise.address.model.person.Phone;
+import spleetwaise.address.model.person.Remark;
 import spleetwaise.address.testutil.Assert;
 import spleetwaise.address.testutil.TypicalPersons;
 
@@ -23,6 +24,7 @@ public class JsonAdaptedPersonTest {
     private static final String INVALID_PHONE = "+651234";
     private static final String INVALID_ADDRESS = " ";
     private static final String INVALID_EMAIL = "example.com";
+    private static final String INVALID_REMARK = "Remark with control char \u0001";
     private static final String INVALID_TAG = "#friend";
 
     private static final String VALID_ID = TypicalPersons.BENSON.getId();
@@ -30,9 +32,9 @@ public class JsonAdaptedPersonTest {
     private static final String VALID_PHONE = TypicalPersons.BENSON.getPhone().toString();
     private static final String VALID_EMAIL = TypicalPersons.BENSON.getEmail().toString();
     private static final String VALID_ADDRESS = TypicalPersons.BENSON.getAddress().toString();
+    private static final String VALID_REMARK = TypicalPersons.BENSON.getRemark().toString();
     private static final List<JsonAdaptedTag> VALID_TAGS = TypicalPersons.BENSON.getTags().stream()
-        .map(JsonAdaptedTag::new)
-        .collect(Collectors.toList());
+            .map(JsonAdaptedTag::new).collect(Collectors.toList());
 
     @Test
     public void toModelType_validPersonDetails_returnsPerson() throws Exception {
@@ -42,72 +44,90 @@ public class JsonAdaptedPersonTest {
 
     @Test
     public void toModelType_invalidId_throwsIllegalValueException() {
-        JsonAdaptedPerson person =
-                new JsonAdaptedPerson(null, VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(
+                null, VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_REMARK, VALID_TAGS);
         Assert.assertThrows(IllegalValueException.class, person::toModelType);
     }
 
     @Test
     public void toModelType_invalidName_throwsIllegalValueException() {
-        JsonAdaptedPerson person =
-            new JsonAdaptedPerson(VALID_ID, INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(
+                VALID_ID, INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_REMARK, VALID_TAGS);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
-        JsonAdaptedPerson person =
-            new JsonAdaptedPerson(VALID_ID, null, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_ID, null, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
+                VALID_REMARK, VALID_TAGS
+        );
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_invalidPhone_throwsIllegalValueException() {
-        JsonAdaptedPerson person =
-            new JsonAdaptedPerson(VALID_ID, VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_ID, VALID_NAME, INVALID_PHONE, VALID_EMAIL,
+                VALID_ADDRESS, VALID_REMARK, VALID_TAGS
+        );
         String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
         Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullPhone_throwsIllegalValueException() {
-        JsonAdaptedPerson person =
-            new JsonAdaptedPerson(VALID_ID, VALID_NAME, null, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(
+                VALID_ID, VALID_NAME, null, VALID_EMAIL, VALID_ADDRESS, VALID_REMARK, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
         Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_invalidEmail_throwsIllegalValueException() {
-        JsonAdaptedPerson person =
-            new JsonAdaptedPerson(VALID_ID, VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(
+                VALID_ID, VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS, VALID_REMARK, VALID_TAGS);
         String expectedMessage = Email.MESSAGE_CONSTRAINTS;
         Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullEmail_throwsIllegalValueException() {
-        JsonAdaptedPerson person =
-            new JsonAdaptedPerson(VALID_ID, VALID_NAME, VALID_PHONE, null, VALID_ADDRESS, VALID_TAGS);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(
+                VALID_ID, VALID_NAME, VALID_PHONE, null, VALID_ADDRESS, VALID_REMARK, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
         Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_invalidAddress_throwsIllegalValueException() {
-        JsonAdaptedPerson person =
-            new JsonAdaptedPerson(VALID_ID, VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS, VALID_TAGS);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(
+                VALID_ID, VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS, VALID_REMARK, VALID_TAGS);
         String expectedMessage = Address.MESSAGE_CONSTRAINTS;
         Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullAddress_throwsIllegalValueException() {
-        JsonAdaptedPerson person =
-            new JsonAdaptedPerson(VALID_ID, VALID_NAME, VALID_PHONE, VALID_EMAIL, null, VALID_TAGS);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(
+                VALID_ID, VALID_NAME, VALID_PHONE, VALID_EMAIL, null, VALID_REMARK, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName());
+        Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+    }
+
+    @Test
+    public void toModelType_invalidRemark_throwsIllegalValueException() {
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_ID, VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
+                INVALID_REMARK, VALID_TAGS
+        );
+        Assert.assertThrows(IllegalValueException.class, person::toModelType);
+    }
+
+    @Test
+    public void toModelType_nullRemark_throwsIllegalValueException() {
+        JsonAdaptedPerson person = new JsonAdaptedPerson(
+                VALID_ID, VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, null, VALID_TAGS);
+        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Remark.class.getSimpleName());
         Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
@@ -115,9 +135,8 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidTags_throwsIllegalValueException() {
         List<JsonAdaptedTag> invalidTags = new ArrayList<>(VALID_TAGS);
         invalidTags.add(new JsonAdaptedTag(INVALID_TAG));
-        JsonAdaptedPerson person =
-            new JsonAdaptedPerson(VALID_ID, VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, invalidTags);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(
+                VALID_ID, VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_REMARK, invalidTags);
         Assert.assertThrows(IllegalValueException.class, person::toModelType);
     }
-
 }

--- a/src/test/java/spleetwaise/address/testutil/EditPersonDescriptorBuilder.java
+++ b/src/test/java/spleetwaise/address/testutil/EditPersonDescriptorBuilder.java
@@ -10,6 +10,7 @@ import spleetwaise.address.model.person.Email;
 import spleetwaise.address.model.person.Name;
 import spleetwaise.address.model.person.Person;
 import spleetwaise.address.model.person.Phone;
+import spleetwaise.address.model.person.Remark;
 import spleetwaise.address.model.tag.Tag;
 
 /**
@@ -37,6 +38,7 @@ public class EditPersonDescriptorBuilder {
         descriptor.setPhone(person.getPhone());
         descriptor.setEmail(person.getEmail());
         descriptor.setAddress(person.getAddress());
+        descriptor.setRemark(person.getRemark());
         descriptor.setTags(person.getTags());
     }
 
@@ -69,6 +71,14 @@ public class EditPersonDescriptorBuilder {
      */
     public EditPersonDescriptorBuilder withAddress(String address) {
         descriptor.setAddress(new Address(address));
+        return this;
+    }
+
+    /**
+     * Sets the {@code Remark} of the {@code EditPersonDescriptor} that we are building.
+     */
+    public EditPersonDescriptorBuilder withRemark(String remark) {
+        descriptor.setRemark(new Remark(remark));
         return this;
     }
 

--- a/src/test/java/spleetwaise/address/testutil/PersonBuilder.java
+++ b/src/test/java/spleetwaise/address/testutil/PersonBuilder.java
@@ -8,6 +8,7 @@ import spleetwaise.address.model.person.Email;
 import spleetwaise.address.model.person.Name;
 import spleetwaise.address.model.person.Person;
 import spleetwaise.address.model.person.Phone;
+import spleetwaise.address.model.person.Remark;
 import spleetwaise.address.model.tag.Tag;
 import spleetwaise.address.model.util.SampleDataUtil;
 import spleetwaise.commons.IdUtil;
@@ -21,12 +22,14 @@ public class PersonBuilder {
     public static final String DEFAULT_PHONE = "85355255";
     public static final String DEFAULT_EMAIL = "amy@gmail.com";
     public static final String DEFAULT_ADDRESS = "123, Jurong West Ave 6, #08-111";
+    private static final String DEFAULT_REMARK = "";
 
     private String id;
     private Name name;
     private Phone phone;
     private Email email;
     private Address address;
+    private Remark remark;
     private Set<Tag> tags;
 
     /**
@@ -38,6 +41,7 @@ public class PersonBuilder {
         phone = new Phone(DEFAULT_PHONE);
         email = new Email(DEFAULT_EMAIL);
         address = new Address(DEFAULT_ADDRESS);
+        remark = new Remark(DEFAULT_REMARK);
         tags = new HashSet<>();
     }
 
@@ -50,6 +54,7 @@ public class PersonBuilder {
         phone = personToCopy.getPhone();
         email = personToCopy.getEmail();
         address = personToCopy.getAddress();
+        remark = personToCopy.getRemark();
         tags = new HashSet<>(personToCopy.getTags());
     }
 
@@ -70,22 +75,6 @@ public class PersonBuilder {
     }
 
     /**
-     * Parses the {@code tags} into a {@code Set<Tag>} and set it to the {@code Person} that we are building.
-     */
-    public PersonBuilder withTags(String... tags) {
-        this.tags = SampleDataUtil.getTagSet(tags);
-        return this;
-    }
-
-    /**
-     * Sets the {@code Address} of the {@code Person} that we are building.
-     */
-    public PersonBuilder withAddress(String address) {
-        this.address = new Address(address);
-        return this;
-    }
-
-    /**
      * Sets the {@code Phone} of the {@code Person} that we are building.
      */
     public PersonBuilder withPhone(String phone) {
@@ -101,8 +90,31 @@ public class PersonBuilder {
         return this;
     }
 
-    public Person build() {
-        return new Person(id, name, phone, email, address, tags);
+    /**
+     * Sets the {@code Address} of the {@code Person} that we are building.
+     */
+    public PersonBuilder withAddress(String address) {
+        this.address = new Address(address);
+        return this;
     }
 
+    /**
+     * Sets the {@code Remark} of the {@code Person} that we are building.
+     */
+    public PersonBuilder withRemark(String remark) {
+        this.remark = new Remark(remark);
+        return this;
+    }
+
+    /**
+     * Parses the {@code tags} into a {@code Set<Tag>} and set it to the {@code Person} that we are building.
+     */
+    public PersonBuilder withTags(String... tags) {
+        this.tags = SampleDataUtil.getTagSet(tags);
+        return this;
+    }
+
+    public Person build() {
+        return new Person(id, name, phone, email, address, remark, tags);
+    }
 }

--- a/src/test/java/spleetwaise/address/testutil/PersonUtil.java
+++ b/src/test/java/spleetwaise/address/testutil/PersonUtil.java
@@ -29,6 +29,7 @@ public class PersonUtil {
         sb.append(CliSyntax.PREFIX_PHONE + person.getPhone().value + " ");
         sb.append(CliSyntax.PREFIX_EMAIL + person.getEmail().value + " ");
         sb.append(CliSyntax.PREFIX_ADDRESS + person.getAddress().value + " ");
+        sb.append(CliSyntax.PREFIX_REMARK + person.getRemark().value + " ");
         person.getTags().stream().forEach(
                 s -> sb.append(CliSyntax.PREFIX_TAG + s.tagName + " ")
         );

--- a/src/test/java/spleetwaise/address/testutil/TypicalPersons.java
+++ b/src/test/java/spleetwaise/address/testutil/TypicalPersons.java
@@ -10,6 +10,8 @@ import static spleetwaise.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
 import static spleetwaise.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static spleetwaise.address.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
 import static spleetwaise.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
+import static spleetwaise.address.logic.commands.CommandTestUtil.VALID_REMARK_AMY;
+import static spleetwaise.address.logic.commands.CommandTestUtil.VALID_REMARK_BOB;
 import static spleetwaise.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
 import static spleetwaise.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 
@@ -26,44 +28,44 @@ import spleetwaise.address.model.person.Person;
 public class TypicalPersons {
 
     public static final Person ALICE = new PersonBuilder().withId("29705d8f-6a2b-4de3-8b86-e8efb3f2215f")
-            .withName("Alice Pauline").withAddress("123, Jurong West Ave 6, #08-111").withEmail("alice@example.com")
-            .withPhone("94351253").withTags("friends").build();
+            .withName("Alice Pauline").withPhone("94351253").withEmail("alice@example.com")
+            .withAddress("123, Jurong West Ave 6, #08-111").withRemark("alice is poor").withTags("friends").build();
     public static final Person BENSON = new PersonBuilder().withId("3929a136-823a-4806-af62-e96b241167b5")
-            .withName("Benson Meier")
-            .withAddress("311, Clementi Ave 2, #02-25").withEmail("johnd@example.com").withPhone("98765432")
-            .withTags("owesMoney", "friends").build();
+            .withName("Benson Meier").withPhone("98765432").withEmail("johnd@example.com")
+            .withAddress("311, Clementi Ave 2, #02-25").withRemark("benson is rich").withTags("owesMoney", "friends")
+            .build();
     public static final Person CARL = new PersonBuilder().withId("60196500-3d01-4e6c-81de-44ab6fc9e7e5")
-            .withName("Carl Kurz").withPhone(
-                    "95352563").withEmail("heinz@example.com").withAddress("wall street").build();
+            .withName("Carl Kurz").withPhone("95352563").withEmail("heinz@example.com").withAddress("wall street")
+            .build();
     public static final Person DANIEL = new PersonBuilder().withId("b89d7c94-9823-4b6a-ae46-b7c55ee41727")
-            .withName("Daniel Meier").withPhone(
-                    "87652533").withEmail("cornelia@example.com").withAddress("10th street").withTags("friends")
+            .withName("Daniel Meier").withPhone("87652533").withEmail("cornelia@example.com").withAddress("10th street")
+            .withRemark("DANIEL IS IN DEBT").withTags("friends")
             .build();
     public static final Person ELLE = new PersonBuilder().withId("42984eac-421f-4966-994d-6f360d7d2882")
-            .withName("Elle Meyer").withPhone(
-                    "9482224").withEmail("werner@example.com").withAddress("michegan ave").build();
+            .withName("Elle Meyer").withPhone("9482224").withEmail("werner@example.com").withAddress("michegan ave")
+            .build();
     public static final Person FIONA = new PersonBuilder().withId("c5a93d37-44fd-4f4d-964b-6f85c715d6e3")
-            .withName("Fiona Kunz").withPhone(
-                    "9482427").withEmail("lydia@example.com").withAddress("little tokyo").build();
+            .withName("Fiona Kunz").withPhone("9482427").withEmail("lydia@example.com").withAddress("little tokyo")
+            .build();
     public static final Person GEORGE = new PersonBuilder().withId("c5a93d37-44fd-4f4d-964b-6f85c715djf93")
-            .withName("George Best").withPhone(
-                    "9482442").withEmail("anna@example.com").withAddress("4th street").build();
+            .withName("George Best").withPhone("9482442").withEmail("anna@example.com").withAddress("4th street")
+            .build();
 
     // Manually added
     public static final Person HOON = new PersonBuilder().withId("c5a93d37-44fd-4f4d-964b-6f85c715djqw3")
-            .withName("Hoon Meier").withPhone("8482424").withEmail("stefan@example.com")
-            .withAddress("little india").build();
+            .withName("Hoon Meier").withPhone("8482424").withEmail("stefan@example.com").withAddress("little india")
+            .build();
     public static final Person IDA = new PersonBuilder().withId("c5a93d37-44fd-4f4d-964b-6f85c715djgr5")
-            .withName("Ida Mueller").withPhone("8482131")
-            .withEmail("hans@example.com").withAddress("chicago ave").build();
+            .withName("Ida Mueller").withPhone("8482131").withEmail("hans@example.com").withAddress("chicago ave")
+            .build();
 
     // Manually added - Person's details found in {@code CommandTestUtil}
     public static final Person AMY = new PersonBuilder().withId(VALID_ID_AMY).withName(VALID_NAME_AMY)
             .withPhone(VALID_PHONE_AMY).withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY)
-            .withTags(VALID_TAG_FRIEND).build();
+            .withRemark(VALID_REMARK_AMY).withTags(VALID_TAG_FRIEND).build();
     public static final Person BOB =
             new PersonBuilder().withId(VALID_ID_BOB).withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
-                    .withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB)
+                    .withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB).withRemark(VALID_REMARK_BOB)
                     .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND)
                     .build();
 


### PR DESCRIPTION
Firstly, Closes #130. Very important use case that aligns with Spleetwaise. E.g. I want to add a contact named Sean Lim who is in debt and potentially bankrupt so that when I see such a remark I will not conduct any transaction with him. 

# Summary
This pull request introduces a new feature to the address book application by adding a "remark" field to the Person class. This change allows users to add, edit, and remove remarks associated with each person in the address book. The PR includes modifications to several classes to support this new functionality, including command classes, parsers, and tests.

# Key Changes
1. AddCommand and EditCommand: Updated to handle the new remark field. The MESSAGE_USAGE and Example strings have been updated to include the remark prefix.

2. RemarkCommand: A new command class that allows users to add or remove remarks from a person in the address book.

3. Parser Updates:
- AddCommandParser, EditCommandParser, and RemarkCommandParser have been updated to parse the remark field.
- CliSyntax now includes a PREFIX_REMARK.

4. Model Changes:
- The Person class now includes a Remark field.
- A new Remark class has been added to represent the remark data.

5. Storage and JSON Adaptation:
- JsonAdaptedPerson has been updated to include the remark field.
- JSON test data files have been updated to include remarks.

6. UI Changes:
- PersonCard and its FXML file have been updated to display the remark.

7. Tests:
- New tests for RemarkCommand and RemarkCommandParser.
- Updated existing tests to handle the remark field.

# TODO:
1. Documentation:
2. Consider adding more detailed comments in the RemarkCommand class to explain the logic behind adding and removing remarks.
3. Ensure that the validation logic for remarks is robust, especially in handling edge cases like empty strings or special characters.