### PR TITLE
Add deleteTxn command

### DIFF
--- a/src/main/java/spleetwaise/address/model/AddressBookModelManager.java
+++ b/src/main/java/spleetwaise/address/model/AddressBookModelManager.java
@@ -98,6 +98,7 @@ public class AddressBookModelManager implements AddressBookModel {
 
     @Override
     public void deletePerson(Person target) {
+        requireNonNull(target);
         addressBook.removePerson(target);
     }
 

--- a/src/main/java/spleetwaise/commons/model/CommonModel.java
+++ b/src/main/java/spleetwaise/commons/model/CommonModel.java
@@ -186,4 +186,10 @@ public class CommonModel implements Model {
         requireNonNull(personId);
         transactionBookModel.deleteTransactionsOfPersonId(personId);
     }
+
+    @Override
+    public void deleteTransaction(Transaction target) {
+        requireNonNull(transactionBookModel, "TransactionBook model cannot be null");
+        transactionBookModel.deleteTransaction(target);
+    }
 }

--- a/src/main/java/spleetwaise/transaction/logic/Messages.java
+++ b/src/main/java/spleetwaise/transaction/logic/Messages.java
@@ -1,0 +1,11 @@
+package spleetwaise.transaction.logic;
+
+/**
+ * Container for user visible messages.
+ */
+public class Messages {
+
+    public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
+    public static final String MESSAGE_INVALID_TRANSACTION_DISPLAYED_INDEX = "The transaction index provided is "
+            + "invalid";
+}

--- a/src/main/java/spleetwaise/transaction/logic/commands/DeleteCommand.java
+++ b/src/main/java/spleetwaise/transaction/logic/commands/DeleteCommand.java
@@ -6,6 +6,7 @@ import java.util.logging.Logger;
 
 import spleetwaise.address.commons.core.LogsCenter;
 import spleetwaise.address.commons.core.index.Index;
+import spleetwaise.address.commons.util.ToStringBuilder;
 import spleetwaise.commons.logic.commands.Command;
 import spleetwaise.commons.logic.commands.CommandResult;
 import spleetwaise.commons.logic.commands.exceptions.CommandException;
@@ -44,7 +45,7 @@ public class DeleteCommand extends Command {
 
         if (targetIndex.getZeroBased() >= lastShownList.size()) {
             logger.log(Level.WARNING, "Invalid transaction index: {0}", targetIndex.getZeroBased());
-            throw new CommandException("The transaction index provided is invalid.");
+            throw new CommandException("The transaction index provided is invalid");
         }
 
         Transaction transactionToDelete = lastShownList.get(targetIndex.getZeroBased());
@@ -68,6 +69,8 @@ public class DeleteCommand extends Command {
 
     @Override
     public String toString() {
-        return "DeleteCommand{targetIndex=" + targetIndex + "}";
+        return new ToStringBuilder(this)
+                .add("targetIndex", targetIndex)
+                .toString();
     }
 }

--- a/src/main/java/spleetwaise/transaction/logic/commands/DeleteCommand.java
+++ b/src/main/java/spleetwaise/transaction/logic/commands/DeleteCommand.java
@@ -1,7 +1,10 @@
 package spleetwaise.transaction.logic.commands;
 
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
+import spleetwaise.address.commons.core.LogsCenter;
 import spleetwaise.address.commons.core.index.Index;
 import spleetwaise.commons.logic.commands.Command;
 import spleetwaise.commons.logic.commands.CommandResult;
@@ -23,6 +26,8 @@ public class DeleteCommand extends Command {
 
     public static final String MESSAGE_DELETE_TRANSACTION_SUCCESS = "Deleted Transaction: %1$s";
 
+    private static final Logger logger = LogsCenter.getLogger(DeleteCommand.class);
+
     private final Index targetIndex;
 
     public DeleteCommand(Index targetIndex) {
@@ -31,16 +36,20 @@ public class DeleteCommand extends Command {
 
     @Override
     public CommandResult execute() throws CommandException {
+        logger.log(Level.INFO, "Executing DeleteCommand with index: {0}", targetIndex.getZeroBased());
+
         CommonModel model = CommonModel.getInstance();
 
         List<Transaction> lastShownList = model.getFilteredTransactionList();
 
         if (targetIndex.getZeroBased() >= lastShownList.size()) {
+            logger.log(Level.WARNING, "Invalid transaction index: {0}", targetIndex.getZeroBased());
             throw new CommandException("The transaction index provided is invalid.");
         }
 
         Transaction transactionToDelete = lastShownList.get(targetIndex.getZeroBased());
         model.deleteTransaction(transactionToDelete);
+        logger.log(Level.INFO, "Deleted transaction: {0}", transactionToDelete);
         return new CommandResult(String.format(MESSAGE_DELETE_TRANSACTION_SUCCESS, transactionToDelete));
     }
 

--- a/src/main/java/spleetwaise/transaction/logic/commands/DeleteCommand.java
+++ b/src/main/java/spleetwaise/transaction/logic/commands/DeleteCommand.java
@@ -1,0 +1,64 @@
+package spleetwaise.transaction.logic.commands;
+
+import java.util.List;
+
+import spleetwaise.address.commons.core.index.Index;
+import spleetwaise.commons.logic.commands.Command;
+import spleetwaise.commons.logic.commands.CommandResult;
+import spleetwaise.commons.logic.commands.exceptions.CommandException;
+import spleetwaise.commons.model.CommonModel;
+import spleetwaise.transaction.model.transaction.Transaction;
+
+/**
+ * Deletes a transaction identified using its displayed index from the transaction book.
+ */
+public class DeleteCommand extends Command {
+
+    public static final String COMMAND_WORD = "deleteTxn";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Deletes the transaction identified by the index number used in the displayed transaction list.\n"
+            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " 1";
+
+    public static final String MESSAGE_DELETE_TRANSACTION_SUCCESS = "Deleted Transaction: %1$s";
+
+    private final Index targetIndex;
+
+    public DeleteCommand(Index targetIndex) {
+        this.targetIndex = targetIndex;
+    }
+
+    @Override
+    public CommandResult execute() throws CommandException {
+        CommonModel model = CommonModel.getInstance();
+
+        List<Transaction> lastShownList = model.getFilteredTransactionList();
+
+        if (targetIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException("The transaction index provided is invalid.");
+        }
+
+        Transaction transactionToDelete = lastShownList.get(targetIndex.getZeroBased());
+        model.deleteTransaction(transactionToDelete);
+        return new CommandResult(String.format(MESSAGE_DELETE_TRANSACTION_SUCCESS, transactionToDelete));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof DeleteCommand otherDeleteCommand)) {
+            return false;
+        }
+
+        return targetIndex.equals(otherDeleteCommand.targetIndex);
+    }
+
+    @Override
+    public String toString() {
+        return "DeleteCommand{targetIndex=" + targetIndex + "}";
+    }
+}

--- a/src/main/java/spleetwaise/transaction/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/spleetwaise/transaction/logic/parser/DeleteCommandParser.java
@@ -1,10 +1,10 @@
-package spleetwaise.address.logic.parser;
+package spleetwaise.transaction.logic.parser;
 
 import static spleetwaise.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import spleetwaise.address.commons.core.index.Index;
-import spleetwaise.address.logic.commands.DeleteCommand;
 import spleetwaise.address.logic.parser.exceptions.ParseException;
+import spleetwaise.transaction.logic.commands.DeleteCommand;
 
 /**
  * Parses input arguments and creates a new DeleteCommand object

--- a/src/main/java/spleetwaise/transaction/logic/parser/ParserUtil.java
+++ b/src/main/java/spleetwaise/transaction/logic/parser/ParserUtil.java
@@ -4,6 +4,8 @@ import static java.util.Objects.requireNonNull;
 
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
+import spleetwaise.address.commons.core.index.Index;
+import spleetwaise.address.commons.util.StringUtil;
 import spleetwaise.address.logic.parser.exceptions.ParseException;
 import spleetwaise.address.model.ReadOnlyAddressBook;
 import spleetwaise.address.model.person.Person;
@@ -17,6 +19,22 @@ import spleetwaise.transaction.model.transaction.Description;
  * Contains utility methods used for parsing strings in the various *Parser classes.
  */
 public class ParserUtil {
+
+    public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
+
+    /**
+     * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
+     * trimmed.
+     *
+     * @throws ParseException if the specified index is invalid (not non-zero unsigned integer).
+     */
+    public static Index parseIndex(String oneBasedIndex) throws ParseException {
+        String trimmedIndex = oneBasedIndex.trim();
+        if (!StringUtil.isNonZeroUnsignedInteger(trimmedIndex)) {
+            throw new ParseException(MESSAGE_INVALID_INDEX);
+        }
+        return Index.fromOneBased(Integer.parseInt(trimmedIndex));
+    }
 
     /**
      * Parses a {@code String amount} into a {@code Amount}. Leading and trailing whitespaces will be trimmed.

--- a/src/main/java/spleetwaise/transaction/logic/parser/TransactionParser.java
+++ b/src/main/java/spleetwaise/transaction/logic/parser/TransactionParser.java
@@ -9,6 +9,7 @@ import spleetwaise.address.logic.parser.exceptions.ParseException;
 import spleetwaise.commons.logic.commands.Command;
 import spleetwaise.transaction.logic.commands.AddCommand;
 import spleetwaise.transaction.logic.commands.ClearCommand;
+import spleetwaise.transaction.logic.commands.DeleteCommand;
 import spleetwaise.transaction.logic.commands.FilterCommand;
 import spleetwaise.transaction.logic.commands.ListCommand;
 
@@ -54,6 +55,8 @@ public class TransactionParser {
             return new ClearCommand();
         case FilterCommand.COMMAND_WORD:
             return new FilterCommandParser().parse(arguments);
+        case DeleteCommand.COMMAND_WORD:
+            return new DeleteCommandParser().parse(arguments);
         default:
             return null;
         }

--- a/src/main/java/spleetwaise/transaction/model/TransactionBookModel.java
+++ b/src/main/java/spleetwaise/transaction/model/TransactionBookModel.java
@@ -47,4 +47,9 @@ public interface TransactionBookModel {
      * Deletes transactions of a person with the given id. Used for when a person is deleted.
      */
     void deleteTransactionsOfPersonId(String personId);
+
+    /**
+     * Deletes the given transaction. Transaction must be present in the transactionBook.
+     */
+    void deleteTransaction(Transaction target);
 }

--- a/src/main/java/spleetwaise/transaction/model/TransactionBookModelManager.java
+++ b/src/main/java/spleetwaise/transaction/model/TransactionBookModelManager.java
@@ -89,6 +89,7 @@ public class TransactionBookModelManager implements TransactionBookModel {
 
     @Override
     public void deleteTransaction(Transaction transaction) {
+        requireNonNull(transaction);
         transactionBook.removeTransaction(transaction);
         updateFilteredTransactionList(PREDICATE_SHOW_ALL_TXNS);
     }

--- a/src/main/java/spleetwaise/transaction/model/TransactionBookModelManager.java
+++ b/src/main/java/spleetwaise/transaction/model/TransactionBookModelManager.java
@@ -88,6 +88,12 @@ public class TransactionBookModelManager implements TransactionBookModel {
     }
 
     @Override
+    public void deleteTransaction(Transaction transaction) {
+        transactionBook.removeTransaction(transaction);
+        updateFilteredTransactionList(PREDICATE_SHOW_ALL_TXNS);
+    }
+
+    @Override
     public boolean equals(Object other) {
         if (other == this) {
             return true;

--- a/src/test/java/spleetwaise/transaction/logic/commands/CommandTestUtil.java
+++ b/src/test/java/spleetwaise/transaction/logic/commands/CommandTestUtil.java
@@ -3,11 +3,16 @@ package spleetwaise.transaction.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import spleetwaise.address.commons.core.index.Index;
+import spleetwaise.address.testutil.Assert;
 import spleetwaise.commons.logic.commands.Command;
 import spleetwaise.commons.logic.commands.CommandResult;
 import spleetwaise.commons.logic.commands.exceptions.CommandException;
 import spleetwaise.commons.model.CommonModel;
+import spleetwaise.transaction.model.TransactionBook;
 import spleetwaise.transaction.model.TransactionBookModel;
 import spleetwaise.transaction.model.transaction.Transaction;
 import spleetwaise.transaction.model.transaction.TransactionIdPredicate;
@@ -46,6 +51,22 @@ public class CommandTestUtil {
     ) {
         CommandResult expectedCommandResult = new CommandResult(expectedMessage);
         assertCommandSuccess(command, actualModel, expectedCommandResult, expectedModel);
+    }
+
+    /**
+     * Executes the given {@code command}, confirms that <br> - a {@code CommandException} is thrown <br> - the
+     * CommandException message matches {@code expectedMessage} <br> - the transaction book, filtered transaction list
+     * and selected transaction in {@code actualModel} remain unchanged
+     */
+    public static void assertCommandFailure(Command command, TransactionBookModel actualModel, String expectedMessage) {
+        // we are unable to defensively copy the model for comparison later, so we can
+        // only do so by copying its components.
+        TransactionBook expectedTransactionBook = new TransactionBook(actualModel.getTransactionBook());
+        List<Transaction> expectedFilteredList = new ArrayList<>(actualModel.getFilteredTransactionList());
+
+        Assert.assertThrows(CommandException.class, expectedMessage, command::execute);
+        assertEquals(expectedTransactionBook, actualModel.getTransactionBook());
+        assertEquals(expectedFilteredList, actualModel.getFilteredTransactionList());
     }
 
     /**

--- a/src/test/java/spleetwaise/transaction/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/spleetwaise/transaction/logic/commands/DeleteCommandTest.java
@@ -8,16 +8,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import spleetwaise.address.commons.core.index.Index;
-import spleetwaise.address.model.AddressBookModel;
-import spleetwaise.address.model.AddressBookModelManager;
-import spleetwaise.address.model.UserPrefs;
-import spleetwaise.transaction.testutil.TypicalIndexes;
-import spleetwaise.address.testutil.TypicalPersons;
 import spleetwaise.commons.model.CommonModel;
 import spleetwaise.transaction.logic.Messages;
 import spleetwaise.transaction.model.TransactionBookModel;
 import spleetwaise.transaction.model.TransactionBookModelManager;
 import spleetwaise.transaction.model.transaction.Transaction;
+import spleetwaise.transaction.testutil.TypicalIndexes;
 import spleetwaise.transaction.testutil.TypicalTransactions;
 
 /**
@@ -25,8 +21,6 @@ import spleetwaise.transaction.testutil.TypicalTransactions;
  */
 public class DeleteCommandTest {
 
-    private final AddressBookModel addressBookModel = new AddressBookModelManager(
-            TypicalPersons.getTypicalAddressBook(), new UserPrefs());
     private final TransactionBookModel transactionBookModel = new TransactionBookModelManager(
             TypicalTransactions.getTypicalTransactionBook()
     );

--- a/src/test/java/spleetwaise/transaction/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/spleetwaise/transaction/logic/commands/DeleteCommandTest.java
@@ -1,0 +1,132 @@
+package spleetwaise.transaction.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import spleetwaise.address.commons.core.index.Index;
+import spleetwaise.address.model.AddressBookModel;
+import spleetwaise.address.model.AddressBookModelManager;
+import spleetwaise.address.model.UserPrefs;
+import spleetwaise.transaction.testutil.TypicalIndexes;
+import spleetwaise.address.testutil.TypicalPersons;
+import spleetwaise.commons.model.CommonModel;
+import spleetwaise.transaction.logic.Messages;
+import spleetwaise.transaction.model.TransactionBookModel;
+import spleetwaise.transaction.model.TransactionBookModelManager;
+import spleetwaise.transaction.model.transaction.Transaction;
+import spleetwaise.transaction.testutil.TypicalTransactions;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for {@code DeleteCommand}.
+ */
+public class DeleteCommandTest {
+
+    private final AddressBookModel addressBookModel = new AddressBookModelManager(
+            TypicalPersons.getTypicalAddressBook(), new UserPrefs());
+    private final TransactionBookModel transactionBookModel = new TransactionBookModelManager(
+            TypicalTransactions.getTypicalTransactionBook()
+    );
+
+    @BeforeEach
+    void setup() {
+        CommonModel.initialise(null, transactionBookModel);
+    }
+
+    @Test
+    public void execute_validIndexUnfilteredList_success() {
+        Transaction transactionToDelete = transactionBookModel.getFilteredTransactionList()
+                .get(TypicalIndexes.INDEX_FIRST_TRANSACTION.getZeroBased());
+        DeleteCommand deleteCommand = new DeleteCommand(TypicalIndexes.INDEX_FIRST_TRANSACTION);
+
+        String expectedMessage = String.format(
+                DeleteCommand.MESSAGE_DELETE_TRANSACTION_SUCCESS,
+                transactionToDelete
+        );
+
+        TransactionBookModelManager expectedModel = new TransactionBookModelManager(
+                transactionBookModel.getTransactionBook());
+        expectedModel.deleteTransaction(transactionToDelete);
+
+        CommandTestUtil.assertCommandSuccess(deleteCommand, transactionBookModel, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(transactionBookModel.getFilteredTransactionList().size() + 1);
+        DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
+
+        CommandTestUtil.assertCommandFailure(
+                deleteCommand, transactionBookModel, Messages.MESSAGE_INVALID_TRANSACTION_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_validIndexFilteredList_success() {
+        CommandTestUtil.showTransactionAtIndex(transactionBookModel, TypicalIndexes.INDEX_FIRST_TRANSACTION);
+
+        Transaction transactionToDelete = transactionBookModel.getFilteredTransactionList()
+                .get(TypicalIndexes.INDEX_FIRST_TRANSACTION.getZeroBased());
+
+        DeleteCommand deleteCommand = new DeleteCommand(TypicalIndexes.INDEX_FIRST_TRANSACTION);
+
+        String expectedMessage = String.format(
+                DeleteCommand.MESSAGE_DELETE_TRANSACTION_SUCCESS,
+                transactionToDelete
+        );
+
+        TransactionBookModelManager expectedModel = new TransactionBookModelManager(
+                transactionBookModel.getTransactionBook());
+        CommandTestUtil.showTransactionAtIndex(expectedModel, TypicalIndexes.INDEX_FIRST_TRANSACTION);
+        expectedModel.deleteTransaction(transactionToDelete);
+
+        CommandTestUtil.assertCommandSuccess(deleteCommand, transactionBookModel, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexFilteredList_throwsCommandException() {
+        CommandTestUtil.showTransactionAtIndex(transactionBookModel, TypicalIndexes.INDEX_FIRST_TRANSACTION);
+
+        Index outOfBoundIndex = TypicalIndexes.INDEX_SECOND_TRANSACTION;
+        // ensures that outOfBoundIndex is still in bounds of transaction book list
+        assertTrue(
+                outOfBoundIndex.getZeroBased() < transactionBookModel.getTransactionBook().getTransactionList().size());
+
+        DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
+
+        CommandTestUtil.assertCommandFailure(
+                deleteCommand, transactionBookModel, Messages.MESSAGE_INVALID_TRANSACTION_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        DeleteCommand deleteFirstCommand = new DeleteCommand(TypicalIndexes.INDEX_FIRST_TRANSACTION);
+        DeleteCommand deleteSecondCommand = new DeleteCommand(TypicalIndexes.INDEX_SECOND_TRANSACTION);
+
+        // same object -> returns true
+        assertEquals(deleteFirstCommand, deleteFirstCommand);
+
+        // same values -> returns true
+        DeleteCommand deleteFirstCommandCopy = new DeleteCommand(TypicalIndexes.INDEX_FIRST_TRANSACTION);
+        assertEquals(deleteFirstCommand, deleteFirstCommandCopy);
+
+        // different types -> returns false
+        assertNotEquals(1, deleteFirstCommand);
+
+        // null -> returns false
+        assertNotEquals(null, deleteFirstCommand);
+
+        // different transaction -> returns false
+        assertNotEquals(deleteFirstCommand, deleteSecondCommand);
+    }
+
+    @Test
+    public void toStringMethod() {
+        Index targetIndex = Index.fromOneBased(1);
+        DeleteCommand deleteCommand = new DeleteCommand(targetIndex);
+        String expected = DeleteCommand.class.getCanonicalName() + "{targetIndex=" + targetIndex + "}";
+        assertEquals(expected, deleteCommand.toString());
+    }
+}

--- a/src/test/java/spleetwaise/transaction/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/spleetwaise/transaction/logic/parser/DeleteCommandParserTest.java
@@ -1,6 +1,7 @@
 package spleetwaise.transaction.logic.parser;
 
 import org.junit.jupiter.api.Test;
+
 import spleetwaise.transaction.logic.Messages;
 import spleetwaise.transaction.logic.commands.DeleteCommand;
 import spleetwaise.transaction.testutil.TypicalIndexes;

--- a/src/test/java/spleetwaise/transaction/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/spleetwaise/transaction/logic/parser/DeleteCommandParserTest.java
@@ -1,0 +1,25 @@
+package spleetwaise.transaction.logic.parser;
+
+import org.junit.jupiter.api.Test;
+import spleetwaise.transaction.logic.Messages;
+import spleetwaise.transaction.logic.commands.DeleteCommand;
+import spleetwaise.transaction.testutil.TypicalIndexes;
+
+public class DeleteCommandParserTest {
+
+    private final DeleteCommandParser parser = new DeleteCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsDeleteCommand() {
+        CommandParserTestUtil.assertParseSuccess(parser, "1",
+                new DeleteCommand(TypicalIndexes.INDEX_FIRST_TRANSACTION)
+        );
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        CommandParserTestUtil.assertParseFailure(parser, "a",
+                String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE)
+        );
+    }
+}

--- a/src/test/java/spleetwaise/transaction/testutil/TypicalIndexes.java
+++ b/src/test/java/spleetwaise/transaction/testutil/TypicalIndexes.java
@@ -7,4 +7,5 @@ import spleetwaise.address.commons.core.index.Index;
  */
 public class TypicalIndexes {
     public static final Index INDEX_FIRST_TRANSACTION = Index.fromOneBased(1);
+    public static final Index INDEX_SECOND_TRANSACTION = Index.fromOneBased(2);
 }


### PR DESCRIPTION
This pull request introduces the implementation of a new command, `deleteTxn`, which allows users to delete transactions from the transaction book by specifying the transaction's index. This feature is part of the effort to address issue #86.

# Key Changes:
- DeleteCommand.java: A new command class that handles the logic for deleting a transaction based on its index.
- DeleteCommandParser.java: A parser class that interprets user input to create a DeleteCommand object.
- CommonModel.java: Added a method to delete a specific transaction.
- TransactionBookModel.java and TransactionBookModelManager.java: Introduced methods to remove a transaction from the transaction book.
- Messages.java: Added user-visible messages related to the delete transaction command.
- ParserUtil.java: Added a utility method to parse indices from user input.
- TransactionParser.java: Updated to include the new `deleteTxn` command.

# Tests: 
- Comprehensive unit and integration tests for the DeleteCommand and DeleteCommandParser to ensure correct functionality and error handling.

# Testing:
Added tests in DeleteCommandTest.java to verify the command's behaviour with valid and invalid indices.
Added tests in DeleteCommandParserTest.java to ensure correct parsing of user input.

# Closing:
This PR closes issue #86 by implementing the `deleteTxn` command, enhancing the application's transaction management capabilities.