### PR TITLE
Add bugfix split panel layout with min width

### DIFF
--- a/src/main/java/spleetwaise/address/ui/MainWindow.java
+++ b/src/main/java/spleetwaise/address/ui/MainWindow.java
@@ -27,13 +27,11 @@ import spleetwaise.transaction.ui.TransactionListPanel;
 public class MainWindow extends UiPart<Stage> {
 
     private static final String FXML = "MainWindow.fxml";
-    private static final double MIN_WIDTH_FOR_SPLIT = 800;
 
     private final Logger logger = LogsCenter.getLogger(getClass());
     private final Stage primaryStage;
     private final Logic logic;
     private final HelpWindow helpWindow;
-    private String currCommand = "list";
     // Independent Ui parts residing in this Ui container
     private PersonListPanel personListPanel;
     private TransactionListPanel transactionListPanel;
@@ -82,9 +80,6 @@ public class MainWindow extends UiPart<Stage> {
         setAccelerators();
 
         helpWindow = new HelpWindow();
-
-        // Add listener to handle layout changes
-        addWindowSizeListener();
     }
 
     public Stage getPrimaryStage() {
@@ -124,51 +119,6 @@ public class MainWindow extends UiPart<Stage> {
                 event.consume();
             }
         });
-    }
-
-    /**
-     * Adds a listener to the window size to adjust the SplitPane based on width.
-     */
-    private void addWindowSizeListener() {
-        primaryStage.widthProperty().addListener((obs, oldVal, newVal) -> {
-            double width = newVal.doubleValue();
-            adjustPaneVisibility(width);
-        });
-
-        adjustPaneVisibility(primaryStage.getWidth()); // initial adjustment based on current window size
-    }
-
-    /**
-     * Adjusts the visibility of the panes based on window width.
-     */
-    private void adjustPaneVisibility(double width) {
-        if (width < MIN_WIDTH_FOR_SPLIT) {
-            hideRightPane();
-            setLeftPaneContent(logic.isTransactionCommand(currCommand));
-        } else {
-            showBothPanes();
-        }
-    }
-
-    private void hideRightPane() {
-        mainSplitPane.getItems().remove(rightPane);
-    }
-
-    private void showBothPanes() {
-        if (!mainSplitPane.getItems().contains(rightPane)) {
-            mainSplitPane.getItems().add(rightPane);
-        }
-        setLeftPaneContent(false); // Always show personListPanel when both panes are visible
-    }
-
-    private void setLeftPaneContent(boolean showTransactionList) {
-        StackPane newPane = showTransactionList ? transactionListPanelPlaceholder : personListPanelPlaceholder;
-        StackPane oldPane = showTransactionList ? personListPanelPlaceholder : transactionListPanelPlaceholder;
-
-        if (!leftPane.getChildren().contains(newPane)) {
-            leftPane.getChildren().remove(oldPane);
-            leftPane.getChildren().add(newPane);
-        }
     }
 
     /**
@@ -244,11 +194,9 @@ public class MainWindow extends UiPart<Stage> {
      */
     private CommandResult executeCommand(String commandText) throws SpleetWaiseCommandException, ParseException {
         try {
-            currCommand = commandText.trim().split("\\s+")[0];
             CommandResult commandResult = logic.execute(commandText);
             logger.info("Result: " + commandResult.getFeedbackToUser());
             resultDisplay.setFeedbackToUser(commandResult.getFeedbackToUser());
-            adjustPaneVisibility(primaryStage.getWidth());
 
             if (commandResult.isShowHelp()) {
                 handleHelp();

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -12,7 +12,7 @@
 <?import javafx.scene.Scene?>
 <?import javafx.stage.Stage?>
 <fx:root xmlns:fx="http://javafx.com/fxml/1" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/17"
-         title="Address App" minWidth="450" minHeight="600" onCloseRequest="#handleExit">
+         title="Address App" minWidth="800" minHeight="600" onCloseRequest="#handleExit">
     <icons>
         <Image url="@/images/address_book_32.png"/>
     </icons>
@@ -58,7 +58,8 @@
                     </VBox>
 
                     <VBox fx:id="rightPane" prefWidth="50.0" maxWidth="1080">
-                        <VBox fx:id="transactionList" styleClass="pane-with-border" VBox.vgrow="ALWAYS">
+                        <VBox fx:id="transactionList" styleClass="pane-with-border" minWidth="340" prefWidth="340"
+                              VBox.vgrow="ALWAYS">
                             <padding>
                                 <Insets top="10" right="10" bottom="10" left="10"/>
                             </padding>


### PR DESCRIPTION
- [X]  This pull request is complete
- [ ]  This pull request is a work in progress

### This PR aims to implement:

- Bug fixing split panel layout where transaction list panel view resets to empty when expands
- Set min width of the app so that it always in split panel view

---

### Acceptance Criteria

- By default, both left pane and right pane always have enough width _(340px)_. 
- By default, the main app always have enough width _(800px)_ and in split panel layout.
- If `preference.json` width and height settings are less than default size, the application will be display in default size, and `preference.json` width and height settings are set to default value.
- During the running of app, the smallest size user can only resized up to is _800px_ width and _600px_ height.


closes #161 