### PR TITLE
Fix add txn with categories

### DIFF
--- a/src/main/java/spleetwaise/address/model/util/SampleDataUtil.java
+++ b/src/main/java/spleetwaise/address/model/util/SampleDataUtil.java
@@ -1,6 +1,7 @@
 package spleetwaise.address.model.util;
 
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -16,6 +17,7 @@ import spleetwaise.address.model.tag.Tag;
 import spleetwaise.transaction.model.ReadOnlyTransactionBook;
 import spleetwaise.transaction.model.TransactionBook;
 import spleetwaise.transaction.model.transaction.Amount;
+import spleetwaise.transaction.model.transaction.Category;
 import spleetwaise.transaction.model.transaction.Date;
 import spleetwaise.transaction.model.transaction.Description;
 import spleetwaise.transaction.model.transaction.Transaction;
@@ -58,16 +60,23 @@ public class SampleDataUtil {
     }
 
     public static Transaction[] getSampleTransactions() {
-        return new Transaction[]{
-            new Transaction(alexYeoh, new Amount("10.00"), new Description("Mc Donald's"), new Date("01012024")),
-            new Transaction(berniceYu, new Amount("5.50"), new Description("Starbucks"), new Date("02022024")),
-            new Transaction(
-                    charlotteOliveiro, new Amount("8.25"), new Description("Pizza Hut"), new Date("03032024")),
-            new Transaction(davidLi, new Amount("12.00"), new Description("NTUC FairPrice"), new Date("04042024")),
-            new Transaction(
-                    irfanIbrahim, new Amount("-9.50"), new Description("Cold Storage"), new Date("05052024")),
-            new Transaction(
-                    royBalakrishnan, new Amount("11.25"), new Description("Old Chang Kee"), new Date("06062024"))
+        Set<Category> emptyCategories = new HashSet<>();
+        return new Transaction[]{ new Transaction(alexYeoh, new Amount("10.00"), new Description("Mc Donald's"),
+                new Date("01012024"), emptyCategories
+        ), new Transaction(
+                berniceYu, new Amount("5.50"), new Description("Starbucks"), new Date("02022024"), emptyCategories
+        ), new Transaction(
+                charlotteOliveiro, new Amount("8.25"), new Description("Pizza Hut"), new Date("03032024"),
+                emptyCategories
+        ), new Transaction(
+                davidLi, new Amount("12.00"), new Description("NTUC FairPrice"), new Date("04042024"), emptyCategories
+        ), new Transaction(
+                irfanIbrahim, new Amount("-9.50"), new Description("Cold Storage"), new Date("05052024"),
+                emptyCategories
+        ), new Transaction(
+                royBalakrishnan, new Amount("11.25"), new Description("Old Chang Kee"), new Date("06062024"),
+                emptyCategories
+        )
         };
     }
 

--- a/src/main/java/spleetwaise/transaction/logic/parser/AddCommandParser.java
+++ b/src/main/java/spleetwaise/transaction/logic/parser/AddCommandParser.java
@@ -7,8 +7,9 @@ import static spleetwaise.transaction.logic.parser.CliSyntax.PREFIX_AMOUNT;
 import static spleetwaise.transaction.logic.parser.CliSyntax.PREFIX_CATEGORY;
 import static spleetwaise.transaction.logic.parser.CliSyntax.PREFIX_DATE;
 import static spleetwaise.transaction.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
+import static spleetwaise.transaction.model.transaction.Date.getNowDate;
 
-import java.util.HashSet;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import spleetwaise.address.logic.parser.ArgumentMultimap;
@@ -47,26 +48,21 @@ public class AddCommandParser implements Parser<AddCommand> {
      */
     public AddCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_PHONE, PREFIX_AMOUNT, PREFIX_DESCRIPTION, PREFIX_DATE);
+                ArgumentTokenizer.tokenize(
+                        args, PREFIX_PHONE, PREFIX_AMOUNT, PREFIX_DESCRIPTION, PREFIX_DATE, PREFIX_CATEGORY);
         if (!arePrefixesPresent(argMultimap, PREFIX_PHONE, PREFIX_AMOUNT, PREFIX_DESCRIPTION)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
         }
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_PHONE, PREFIX_AMOUNT, PREFIX_DESCRIPTION);
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_PHONE, PREFIX_AMOUNT, PREFIX_DESCRIPTION, PREFIX_DATE);
         Phone phone = spleetwaise.address.logic.parser.ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
         Person person = ParserUtil.getPersonFromPhone(phone);
         Amount amount = ParserUtil.parseAmount(argMultimap.getValue(PREFIX_AMOUNT).get());
         Description description = ParserUtil.parseDescription(argMultimap.getValue(PREFIX_DESCRIPTION).get());
-        HashSet<Category> categories = ParserUtil.parseCategories(argMultimap.getAllValues(PREFIX_CATEGORY));
+        Date date = ParserUtil.parseDate(argMultimap.getValue(PREFIX_DATE).orElse(getNowDate()));
+        Set<Category> categories = ParserUtil.parseCategories(argMultimap.getAllValues(PREFIX_CATEGORY));
 
-        Transaction transaction;
-
-        if (argMultimap.getValue(PREFIX_DATE).isPresent()) {
-            Date date = ParserUtil.parseDate(argMultimap.getValue(PREFIX_DATE).get());
-            transaction = new Transaction(person, amount, description, date, categories);
-        } else {
-            transaction = new Transaction(person, amount, description, categories);
-        }
+        Transaction transaction = new Transaction(person, amount, description, date, categories);
 
         return new AddCommand(transaction);
     }

--- a/src/main/java/spleetwaise/transaction/logic/parser/ParserUtil.java
+++ b/src/main/java/spleetwaise/transaction/logic/parser/ParserUtil.java
@@ -84,8 +84,8 @@ public class ParserUtil {
     }
 
     /**
-     * Parses a {@code String catStr} into a {@code Category} that represents the category.
-     * Leading and trailing whitespaces will be trimmed and capitalized
+     * Parses a {@code String catStr} into a {@code Category} that represents the category. Leading and trailing
+     * whitespaces will be trimmed and capitalized
      */
     public static Category parseCategory(String catStr) throws ParseException {
         requireNonNull(catStr);

--- a/src/main/java/spleetwaise/transaction/model/transaction/Category.java
+++ b/src/main/java/spleetwaise/transaction/model/transaction/Category.java
@@ -40,11 +40,10 @@ public class Category {
         }
 
         // instanceof handles nulls
-        if (!(other instanceof Category)) {
+        if (!(other instanceof Category otherCategory)) {
             return false;
         }
 
-        Category otherCategory = (Category) other;
         return category.equals(otherCategory.category);
     }
 

--- a/src/main/java/spleetwaise/transaction/model/transaction/Date.java
+++ b/src/main/java/spleetwaise/transaction/model/transaction/Date.java
@@ -44,8 +44,8 @@ public class Date {
         }
     }
 
-    public static Date getNowDate() {
-        return new Date(LocalDate.now().format(VALIDATION_FORMATTER));
+    public static String getNowDate() {
+        return LocalDate.now().format(VALIDATION_FORMATTER);
     }
 
     public LocalDate getDate() {

--- a/src/main/java/spleetwaise/transaction/model/transaction/Transaction.java
+++ b/src/main/java/spleetwaise/transaction/model/transaction/Transaction.java
@@ -87,10 +87,6 @@ public class Transaction {
         return Collections.unmodifiableSet(categories);
     }
 
-    public boolean containsCategory(Category cat) {
-        return categories.contains(cat);
-    }
-
     /**
      * Returns true if both transactions have the same uuid.
      *

--- a/src/main/java/spleetwaise/transaction/model/transaction/Transaction.java
+++ b/src/main/java/spleetwaise/transaction/model/transaction/Transaction.java
@@ -2,7 +2,9 @@ package spleetwaise.transaction.model.transaction;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.Set;
 
 import spleetwaise.address.commons.util.CollectionUtil;
 import spleetwaise.address.model.person.Person;
@@ -19,7 +21,7 @@ public class Transaction {
     private final Amount amount;
     private final Description description;
     private final Date date;
-    private final HashSet<Category> categories;
+    private final Set<Category> categories = new HashSet<>();
 
     /**
      * Represents a Transaction in the transaction book.
@@ -29,17 +31,19 @@ public class Transaction {
      * @param amount      The amount involved in this transaction.
      * @param description The description of the transaction.
      * @param date        The date the transaction has taken place.
-     * @param categories        The categories the transaction has.
+     * @param categories  The categories the transaction has.
      */
-    public Transaction(String id, Person person, Amount amount, Description description, Date date,
-                       HashSet<Category> categories) {
+    public Transaction(
+            String id, Person person, Amount amount, Description description, Date date,
+            Set<Category> categories
+    ) {
         CollectionUtil.requireAllNonNull(person, amount, description, date, categories);
         this.id = id;
         this.person = person;
         this.amount = amount;
         this.description = description;
         this.date = date;
-        this.categories = categories;
+        this.categories.addAll(categories);
     }
 
     /**
@@ -49,21 +53,10 @@ public class Transaction {
      * @param amount      The amount involved in this transaction.
      * @param description The description of the transaction.
      * @param date        The date the transaction has taken place.
+     * @param categories  The categories the transaction has.
      */
-    public Transaction(Person person, Amount amount, Description description, Date date, HashSet<Category> categories) {
+    public Transaction(Person person, Amount amount, Description description, Date date, Set<Category> categories) {
         this(IdUtil.getId(), person, amount, description, date, categories);
-    }
-
-    public Transaction(Person person, Amount amount, Description description, Date date) {
-        this(IdUtil.getId(), person, amount, description, date, new HashSet<>());
-    }
-
-    public Transaction(Person person, Amount amount, Description description, HashSet<Category> categories) {
-        this(IdUtil.getId(), person, amount, description, Date.getNowDate(), categories);
-    }
-
-    public Transaction(Person person, Amount amount, Description description) {
-        this(IdUtil.getId(), person, amount, description, Date.getNowDate(), new HashSet<>());
     }
 
     public String getId() {
@@ -86,8 +79,12 @@ public class Transaction {
         return date;
     }
 
-    public HashSet<Category> getCategories() {
-        return categories;
+    /**
+     * Returns an immutable category set, which throws {@code UnsupportedOperationException} if modification is
+     * attempted.
+     */
+    public Set<Category> getCategories() {
+        return Collections.unmodifiableSet(categories);
     }
 
     public boolean containsCategory(Category cat) {
@@ -106,10 +103,9 @@ public class Transaction {
             return true;
         }
 
-        if (!(other instanceof Transaction)) {
+        if (!(other instanceof Transaction otherTransaction)) {
             return false;
         }
-        Transaction otherTransaction = (Transaction) other;
         return this.person.equals(otherTransaction.getPerson())
                 && this.amount.equals(otherTransaction.getAmount())
                 && this.description.equals(otherTransaction.getDescription())

--- a/src/test/java/spleetwaise/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/spleetwaise/address/logic/commands/DeleteCommandTest.java
@@ -1,8 +1,10 @@
 package spleetwaise.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashSet;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -28,9 +30,9 @@ import spleetwaise.transaction.model.transaction.Transaction;
  */
 public class DeleteCommandTest {
 
-    private AddressBookModel addressBookModel = new AddressBookModelManager(
+    private final AddressBookModel addressBookModel = new AddressBookModelManager(
             TypicalPersons.getTypicalAddressBook(), new UserPrefs());
-    private TransactionBookModel transactionBookModel = new TransactionBookModelManager();
+    private final TransactionBookModel transactionBookModel = new TransactionBookModelManager();
 
     @BeforeEach
     void setup() {
@@ -73,8 +75,7 @@ public class DeleteCommandTest {
 
         // Add some txn for this person
         transactionBookModel.addTransaction(new Transaction(personToDelete, new Amount("10.00"),
-                new Description("foo"), new Date(
-                "01012024")
+                new Description("foo"), new Date("01012024"), new HashSet<>()
         ));
 
         DeleteCommand deleteCommand = new DeleteCommand(TypicalIndexes.INDEX_FIRST_PERSON);
@@ -120,20 +121,20 @@ public class DeleteCommandTest {
         DeleteCommand deleteSecondCommand = new DeleteCommand(TypicalIndexes.INDEX_SECOND_PERSON);
 
         // same object -> returns true
-        assertTrue(deleteFirstCommand.equals(deleteFirstCommand));
+        assertEquals(deleteFirstCommand, deleteFirstCommand);
 
         // same values -> returns true
         DeleteCommand deleteFirstCommandCopy = new DeleteCommand(TypicalIndexes.INDEX_FIRST_PERSON);
-        assertTrue(deleteFirstCommand.equals(deleteFirstCommandCopy));
+        assertEquals(deleteFirstCommand, deleteFirstCommandCopy);
 
         // different types -> returns false
-        assertFalse(deleteFirstCommand.equals(1));
+        assertNotEquals(1, deleteFirstCommand);
 
         // null -> returns false
-        assertFalse(deleteFirstCommand.equals(null));
+        assertNotEquals(null, deleteFirstCommand);
 
         // different person -> returns false
-        assertFalse(deleteFirstCommand.equals(deleteSecondCommand));
+        assertNotEquals(deleteFirstCommand, deleteSecondCommand);
     }
 
     @Test

--- a/src/test/java/spleetwaise/transaction/logic/commands/AddCommandTest.java
+++ b/src/test/java/spleetwaise/transaction/logic/commands/AddCommandTest.java
@@ -6,6 +6,10 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
 import org.junit.jupiter.api.Test;
 
 import spleetwaise.address.model.person.Person;
@@ -16,6 +20,7 @@ import spleetwaise.commons.logic.commands.exceptions.CommandException;
 import spleetwaise.commons.model.CommonModel;
 import spleetwaise.transaction.model.TransactionBookModelManager;
 import spleetwaise.transaction.model.transaction.Amount;
+import spleetwaise.transaction.model.transaction.Category;
 import spleetwaise.transaction.model.transaction.Date;
 import spleetwaise.transaction.model.transaction.Description;
 import spleetwaise.transaction.model.transaction.Transaction;
@@ -26,7 +31,9 @@ public class AddCommandTest {
     private static final Amount testAmount = new Amount("1.23");
     private static final Description testDescription = new Description("description");
     private static final Date testDate = new Date("01012024");
-    private static final Transaction testTxn = new Transaction(testPerson, testAmount, testDescription, testDate);
+    private static final Set<Category> testCategories = new HashSet<>(List.of(new Category("FOOD")));
+    private static final Transaction testTxn = new Transaction(
+            testPerson, testAmount, testDescription, testDate, testCategories);
 
     @Test
     public void constructor_null_exceptionThrown() {
@@ -34,13 +41,13 @@ public class AddCommandTest {
     }
 
     @Test
-    public void execute_validPerson_success() {
+    public void execute_validTransaction_success() {
         CommonModel.initialise(null, new TransactionBookModelManager());
         AddCommand cmd = new AddCommand(testTxn);
         CommandResult cmdRes = assertDoesNotThrow(cmd::execute);
 
         String expectedString = String.format(
-                "[%s] Alice Pauline(94351253): description on 01/01/2024 for $1.23 with categories: []",
+                "[%s] Alice Pauline(94351253): description on 01/01/2024 for $1.23 with categories: [FOOD]",
                 testTxn.getId()
         );
         assertEquals(
@@ -51,7 +58,7 @@ public class AddCommandTest {
     }
 
     @Test
-    public void execute_duplicatePerson_exceptionThrown() {
+    public void execute_duplicateTransaction_exceptionThrown() {
         CommonModel.initialise(null, new TransactionBookModelManager());
         CommonModel.getInstance().addTransaction(testTxn);
 
@@ -71,7 +78,8 @@ public class AddCommandTest {
     @Test
     public void equals_diffTransaction_returnsFalse() {
         AddCommand cmd1 = new AddCommand(testTxn);
-        Transaction testTxn2 = new Transaction(TypicalPersons.BOB, testAmount, testDescription, testDate);
+        Transaction testTxn2 = new Transaction(
+                TypicalPersons.BOB, testAmount, testDescription, testDate, testCategories);
         AddCommand cmd2 = new AddCommand(testTxn2);
 
         assertNotEquals(cmd1, cmd2);

--- a/src/test/java/spleetwaise/transaction/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/spleetwaise/transaction/logic/parser/AddCommandParserTest.java
@@ -1,8 +1,15 @@
 package spleetwaise.transaction.logic.parser;
 
 import static spleetwaise.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static spleetwaise.transaction.logic.parser.CliSyntax.PREFIX_CATEGORY;
+import static spleetwaise.transaction.logic.parser.CliSyntax.PREFIX_DATE;
 import static spleetwaise.transaction.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static spleetwaise.transaction.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static spleetwaise.transaction.model.transaction.Date.getNowDate;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -14,18 +21,20 @@ import spleetwaise.address.testutil.TypicalPersons;
 import spleetwaise.commons.model.CommonModel;
 import spleetwaise.transaction.logic.commands.AddCommand;
 import spleetwaise.transaction.model.transaction.Amount;
+import spleetwaise.transaction.model.transaction.Category;
 import spleetwaise.transaction.model.transaction.Date;
 import spleetwaise.transaction.model.transaction.Description;
 import spleetwaise.transaction.model.transaction.Transaction;
 
 public class AddCommandParserTest {
 
-    private static Person testPerson = TypicalPersons.ALICE;
-    private static Amount testAmount = new Amount("1.23");
-    private static Description testDescription = new Description("description");
-    private static Date testDate = new Date("01012024");
+    private static final Person testPerson = TypicalPersons.ALICE;
+    private static final Amount testAmount = new Amount("1.23");
+    private static final Description testDescription = new Description("description");
+    private static final Date testDate = new Date(getNowDate());
+    private static final Set<Category> testCategories = new HashSet<>(List.of(new Category("FOOD")));
 
-    private AddCommandParser parser = new AddCommandParser();
+    private final AddCommandParser parser = new AddCommandParser();
 
     @BeforeEach
     void setup() {
@@ -36,8 +45,9 @@ public class AddCommandParserTest {
     public void parse_allFieldsPresent_success() {
         CommonModel.getInstance().addPerson(testPerson);
 
-        String userInput = " p/94351253 amt/1.23 desc/description";
-        Transaction txn = new Transaction(testPerson, testAmount, testDescription);
+        String userInput =
+                " p/94351253 amt/1.23 desc/description " + PREFIX_CATEGORY + "FOOD";
+        Transaction txn = new Transaction(testPerson, testAmount, testDescription, testDate, testCategories);
         assertParseSuccess(parser, userInput, new AddCommand(txn));
     }
 
@@ -45,8 +55,9 @@ public class AddCommandParserTest {
     public void parse_withOptionalDateField_success() {
         CommonModel.getInstance().addPerson(testPerson);
 
-        String userInput = " p/94351253 amt/1.23 desc/description date/01012024";
-        Transaction txn = new Transaction(testPerson, testAmount, testDescription, testDate);
+        String userInput =
+                " p/94351253 amt/1.23 desc/description " + PREFIX_DATE + getNowDate() + " " + PREFIX_CATEGORY + "FOOD";
+        Transaction txn = new Transaction(testPerson, testAmount, testDescription, testDate, testCategories);
         assertParseSuccess(parser, userInput, new AddCommand(txn));
     }
 

--- a/src/test/java/spleetwaise/transaction/model/ModelManagerTest.java
+++ b/src/test/java/spleetwaise/transaction/model/ModelManagerTest.java
@@ -2,10 +2,12 @@ package spleetwaise.transaction.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collections;
+import java.util.Set;
 import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
@@ -15,24 +17,29 @@ import spleetwaise.address.model.AddressBookModelManager;
 import spleetwaise.address.model.person.Person;
 import spleetwaise.address.testutil.TypicalPersons;
 import spleetwaise.transaction.model.transaction.Amount;
+import spleetwaise.transaction.model.transaction.Category;
 import spleetwaise.transaction.model.transaction.Date;
 import spleetwaise.transaction.model.transaction.Description;
 import spleetwaise.transaction.model.transaction.Transaction;
 
 public class ModelManagerTest {
 
-    private static Person testPerson = TypicalPersons.ALICE;
-    private static Amount testAmount = new Amount("1.23");
-    private static Description testDescription = new Description("1");
-    private static Date testDate = new Date("01012024");
+    private static final Person testPerson = TypicalPersons.ALICE;
+    private static final Amount testAmount = new Amount("1.23");
+    private static final Description testDescription = new Description("1");
+    private static final Date testDate = new Date("01012024");
+    private static final Set<Category> testCategories = Collections.emptySet();
 
-    private static Transaction testTxn = new Transaction(testPerson, testAmount, testDescription, testDate);
-    private static Transaction testTxn2 = new Transaction(testPerson, testAmount, new Description("2"), testDate);
-    private static Transaction testTxn3 = new Transaction(testPerson, testAmount, new Description("3"), testDate);
+    private static final Transaction testTxn = new Transaction(
+            testPerson, testAmount, testDescription, testDate, testCategories);
+    private static final Transaction testTxn2 = new Transaction(
+            testPerson, testAmount, new Description("2"), testDate, testCategories);
+    private static final Transaction testTxn3 = new Transaction(
+            testPerson, testAmount, new Description("3"), testDate, testCategories);
 
 
-    private TransactionBookModel transactionModel = new TransactionBookModelManager();
-    private AddressBookModel addressBookModel = new AddressBookModelManager();
+    private final TransactionBookModel transactionModel = new TransactionBookModelManager();
+    private final AddressBookModel addressBookModel = new AddressBookModelManager();
 
     @Test
     void transactionModelIsNotAddressBookModel() {
@@ -149,7 +156,7 @@ public class ModelManagerTest {
     public void equals_null_returnsFalse() {
         TransactionBookModelManager manager = new TransactionBookModelManager();
 
-        assertFalse(manager.equals(null));
+        assertNotEquals(null, manager);
     }
 
     @Test
@@ -159,7 +166,7 @@ public class ModelManagerTest {
         TransactionBookModelManager manager2 = new TransactionBookModelManager();
         manager2.addTransaction(testTxn2);
 
-        assertFalse(manager1.equals(manager2));
+        assertNotEquals(manager1, manager2);
     }
 
     @Test
@@ -176,7 +183,7 @@ public class ModelManagerTest {
         Predicate<Transaction> pred2 = (t) -> t.getDescription().equals(new Description("3"));
         manager1.updateFilteredTransactionList(pred2);
 
-        assertFalse(manager1.equals(manager2));
+        assertNotEquals(manager1, manager2);
     }
 
     @Test
@@ -184,12 +191,12 @@ public class ModelManagerTest {
         TransactionBookModelManager manager1 = new TransactionBookModelManager();
         manager1.addTransaction(testTxn);
 
-        assertTrue(manager1.equals(manager1));
+        assertEquals(manager1, manager1);
 
         TransactionBookModelManager manager2 = new TransactionBookModelManager();
         manager2.addTransaction(testTxn);
 
-        assertTrue(manager1.equals(manager2));
+        assertEquals(manager1, manager2);
     }
 
 

--- a/src/test/java/spleetwaise/transaction/model/TransactionBookTest.java
+++ b/src/test/java/spleetwaise/transaction/model/TransactionBookTest.java
@@ -3,16 +3,21 @@ package spleetwaise.transaction.model;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
 import spleetwaise.address.model.person.Person;
 import spleetwaise.address.testutil.TypicalPersons;
 import spleetwaise.transaction.model.transaction.Amount;
+import spleetwaise.transaction.model.transaction.Category;
 import spleetwaise.transaction.model.transaction.Date;
 import spleetwaise.transaction.model.transaction.Description;
 import spleetwaise.transaction.model.transaction.Transaction;
@@ -25,10 +30,14 @@ public class TransactionBookTest {
     private static final Amount testAmount = new Amount("1.23");
     private static final Description testDescription = new Description("description");
     private static final Date testDate = new Date("01012024");
+    private static final Set<Category> testCategories = new HashSet<>(List.of(new Category("FOOD")));
 
-    private static final Transaction testTxn = new Transaction(testPerson, testAmount, testDescription, testDate);
-    private static final Transaction testTxn2 = new Transaction(testPerson, testAmount, new Description("2"), testDate);
-    private static final Transaction testTxn3 = new Transaction(testPerson, testAmount, new Description("3"), testDate);
+    private static final Transaction testTxn = new Transaction(
+            testPerson, testAmount, testDescription, testDate, testCategories);
+    private static final Transaction testTxn2 = new Transaction(
+            testPerson, testAmount, new Description("2"), testDate, testCategories);
+    private static final Transaction testTxn3 = new Transaction(
+            testPerson, testAmount, new Description("3"), testDate, testCategories);
 
     @Test
     public void constructor_noParams_success() {
@@ -145,12 +154,12 @@ public class TransactionBookTest {
         TransactionBook book = new TransactionBook();
         book.addTransaction(testTxn);
 
-        assertTrue(book.equals(book));
+        assertEquals(book, book);
 
         TransactionBook book2 = new TransactionBook();
         book2.addTransaction(testTxn);
 
-        assertTrue(book.equals(book2));
+        assertEquals(book, book2);
     }
 
     @Test
@@ -158,12 +167,12 @@ public class TransactionBookTest {
         TransactionBook book = new TransactionBook();
         book.addTransaction(testTxn);
 
-        assertFalse(book.equals(null));
+        assertNotEquals(null, book);
 
         TransactionBook book2 = new TransactionBook();
         book2.addTransaction(testTxn2);
 
-        assertFalse(book.equals(book2));
+        assertNotEquals(book, book2);
     }
 
 }

--- a/src/test/java/spleetwaise/transaction/model/transaction/TransactionTest.java
+++ b/src/test/java/spleetwaise/transaction/model/transaction/TransactionTest.java
@@ -3,10 +3,11 @@ package spleetwaise.transaction.model.transaction;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashSet;
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
@@ -16,69 +17,67 @@ import spleetwaise.transaction.testutil.TransactionBuilder;
 
 public class TransactionTest {
 
-    private static Person testPerson = TypicalPersons.ALICE;
-    private static Amount testAmount = new Amount("1.23");
-    private static Description testDescription = new Description("description");
-    private static Date testDate = new Date("01012024");
+    private static final Person testPerson = TypicalPersons.ALICE;
+    private static final Amount testAmount = new Amount("1.23");
+    private static final Description testDescription = new Description("description");
+    private static final Date testDate = new Date("01012024");
+    private static final Set<Category> testCategories = new HashSet<>(TransactionBuilder.DEFAULT_CATEGORY_SET);
 
     @Test
     public void constructor_nullParams_exceptionThrown() {
         assertThrows(NullPointerException.class, () -> new Transaction(null, testAmount,
-                testDescription, testDate));
+                testDescription, testDate, testCategories
+        ));
         assertThrows(NullPointerException.class, () -> new Transaction(testPerson, null,
-                testDescription, testDate));
+                testDescription, testDate, testCategories
+        ));
         assertThrows(NullPointerException.class, () -> new Transaction(testPerson, testAmount,
-                null, testDate));
+                null, testDate, testCategories
+        ));
         assertThrows(NullPointerException.class, () -> new Transaction(testPerson, testAmount,
-                testDescription, (Date) null));
+                testDescription, null, testCategories
+        ));
         assertThrows(NullPointerException.class, () -> new Transaction(testPerson, testAmount,
-                testDescription, (HashSet<Category>) null));
+                testDescription, null, null
+        ));
     }
 
     @Test
     public void constructor_validParams_success() {
-        assertDoesNotThrow(() -> new Transaction(testPerson, testAmount, testDescription, testDate));
-    }
-
-    @Test
-    public void constructor_noDateParam_success() {
-        Date nowDate = Date.getNowDate();
-        Transaction noDateTxn = new Transaction(testPerson, testAmount, testDescription);
-        assertEquals(nowDate, noDateTxn.getDate());
-
+        assertDoesNotThrow(() -> new Transaction(testPerson, testAmount, testDescription, testDate, testCategories));
     }
 
     @Test
     public void equals_validArgument_returnsTrue() {
-        Transaction txn1 = new Transaction(testPerson, testAmount, testDescription, testDate);
-        Transaction txn2 = new Transaction(testPerson, testAmount, testDescription, testDate);
+        Transaction txn1 = new Transaction(testPerson, testAmount, testDescription, testDate, testCategories);
+        Transaction txn2 = new Transaction(testPerson, testAmount, testDescription, testDate, testCategories);
 
-        assertTrue(txn1.equals(txn2));
+        assertEquals(txn1, txn2);
 
-        assertTrue(txn1.equals(txn1));
+        assertEquals(txn1, txn1);
     }
 
     @Test
     public void equals_invalidArgument_returnsFalse() {
-        Transaction txn1 = new Transaction(testPerson, testAmount, testDescription, testDate);
+        Transaction txn1 = new Transaction(testPerson, testAmount, testDescription, testDate, testCategories);
 
         Person testPerson2 = TypicalPersons.BOB;
-        Transaction txn2 = new Transaction(testPerson2, testAmount, testDescription, testDate);
-        assertFalse(txn1.equals(txn2));
+        Transaction txn2 = new Transaction(testPerson2, testAmount, testDescription, testDate, testCategories);
+        assertNotEquals(txn1, txn2);
 
         Amount testAmount2 = new Amount("-1.23");
-        txn2 = new Transaction(testPerson, testAmount2, testDescription, testDate);
-        assertFalse(txn1.equals(txn2));
+        txn2 = new Transaction(testPerson, testAmount2, testDescription, testDate, testCategories);
+        assertNotEquals(txn1, txn2);
 
         Description testDescription2 = new Description("description2");
-        txn2 = new Transaction(testPerson, testAmount, testDescription2, testDate);
-        assertFalse(txn1.equals(txn2));
+        txn2 = new Transaction(testPerson, testAmount, testDescription2, testDate, testCategories);
+        assertNotEquals(txn1, txn2);
 
         Date testDate2 = new Date("02012024");
-        txn2 = new Transaction(testPerson, testAmount, testDescription, testDate2);
-        assertFalse(txn1.equals(txn2));
+        txn2 = new Transaction(testPerson, testAmount, testDescription, testDate2, testCategories);
+        assertNotEquals(txn1, txn2);
 
-        assertFalse(txn1.equals(null));
+        assertNotEquals(null, txn1);
     }
 
     @Test
@@ -99,7 +98,8 @@ public class TransactionTest {
     @Test
     public void toString_success() {
         Transaction txn1 = new Transaction(testPerson, testAmount, testDescription, testDate,
-                TransactionBuilder.DEFAULT_CATEGORY_SET);
+                TransactionBuilder.DEFAULT_CATEGORY_SET
+        );
 
         assertEquals(
                 String.format("[%s] Alice Pauline(94351253): description on 01/01/2024 for $1.23 with categories: "

--- a/src/test/java/spleetwaise/transaction/testutil/TransactionBuilder.java
+++ b/src/test/java/spleetwaise/transaction/testutil/TransactionBuilder.java
@@ -2,6 +2,7 @@ package spleetwaise.transaction.testutil;
 
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Set;
 
 import spleetwaise.address.model.person.Person;
 import spleetwaise.address.testutil.TypicalPersons;
@@ -24,14 +25,14 @@ public class TransactionBuilder {
     private static final String DEFAULT_POSITIVE_AMOUNT = "1.23";
     private static final String DEFAULT_NEGATIVE_AMOUNT = "-1.23";
     private static final Category DEFAULT_CATEGORY = new Category("FOOD");
-    public static final HashSet<Category> DEFAULT_CATEGORY_SET = new HashSet<>(Arrays.asList(DEFAULT_CATEGORY));
+    public static final Set<Category> DEFAULT_CATEGORY_SET = new HashSet<>(Arrays.asList(DEFAULT_CATEGORY));
 
     private String id;
     private Person person;
     private Amount amount;
     private Description description;
     private Date date;
-    private HashSet<Category> categories;
+    private Set<Category> categories;
 
     /**
      * Creates a {@code TransactionBuilder} with the default details.
@@ -101,7 +102,7 @@ public class TransactionBuilder {
     /**
      * Sets the {@code Category} hashset of the {@code Transaction} that we are building.
      */
-    public TransactionBuilder withCategories(HashSet<Category> categories) {
+    public TransactionBuilder withCategories(Set<Category> categories) {
         this.categories = categories;
         return this;
     }


### PR DESCRIPTION
This pull request addresses the issue of adding transactions with categories in the application. The changes ensure that transactions can now be associated with categories, enhancing the functionality and organization of transaction data.

# Key Changes
- Category Handling: Introduced the Category class to represent transaction categories. Transactions can now include a set of categories.
- Sample Data Update: Updated SampleDataUtil to include categories in sample transactions, ensuring that the sample data reflects the new functionality.
- Parser Adjustments: Modified AddCommandParser to handle category input, allowing users to specify categories when adding transactions.
- Transaction Class Update: Refactored the Transaction class to store categories as set

# Tests
- Updated existing tests to include category handling.

TODO:
- Add more tests for categories