### PR TITLE
Add `EditTxn` Command

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -98,13 +98,15 @@ Examples:
 
 Adds a transaction to the transaction book.
 
-Format: `addTxn p/PHONE_NUMBER amt/AMOUNT desc/TEST [date/DATE]`
+Format: `addTxn [p/PHONE_NUMBER] [amt/AMOUNT] [desc/TEST] [date/DATE] [cat/CATEGORY]...`
+
 * The `PHONE_NUMBER` refers to the phone number associated to the person had a transaction with.
-* The `AMOUNT` accepts a decimal number with up to 2 decimal places. A `-` can be added as prefix to indicate negative 
-amount.
+* The `AMOUNT` accepts a decimal number with up to 2 decimal places. A `-` can be added as prefix to indicate negative
+  amount.
 * The `DATE` accepts date formatted in the form `DDMMYYYY` i.e.`10102024`.
 
 :bulb: **Tip:** If the transaction happened on the current day, the date parameter can be omitted.
+:bulb: **Tip:** A person can have any number of categories (including 0)
 
 Examples:
 
@@ -164,7 +166,7 @@ Examples:
 
 ### Filtering transactions: `filterTxn`
 
-Filter transactions with the specified person identified by their phone number, and/or amount and/or description 
+Filter transactions with the specified person identified by their phone number, and/or amount and/or description
 and/or date.
 
 Format: `filterTxn [p/PHONE_NUMBER] [amt/AMOUNT] [desc/DESCRIPTION] [date/DATE]`
@@ -173,18 +175,19 @@ Format: `filterTxn [p/PHONE_NUMBER] [amt/AMOUNT] [desc/DESCRIPTION] [date/DATE]`
 * As more prefixes are provided, the filter becomes more specific.
 * The `PHONE_NUMBER` refers to the phone number associated to the person had a transaction with.
 * The `AMOUNT` accepts a decimal number with up to 2 decimal places. A `-` can be added as prefix to indicate negative
-amount.
+  amount.
 * The `DATE` accepts date formatted in the form `DDMMYYYY` i.e.`10102024`.
 * The `DESCRIPTION` accepts a string of words.
-  * The description filter is case-insensitive. e.g `hans` will match `Hans`
+    * The description filter is case-insensitive. e.g `hans` will match `Hans`
 
 Examples:<br>
+
 * Given the example transaction book:<br>
-![Given the example transaction book](images/filterTxnExample.png)
+  ![Given the example transaction book](images/filterTxnExample.png)
 * `filterTxn p/87438807` returns all transactions with the person `Alex Yeoh`.<br>
-![result fpr 'filterTxn p/87438807'](images/filterTxnAlexYeohResult.png)
+  ![result fpr 'filterTxn p/87438807'](images/filterTxnAlexYeohResult.png)
 * `filterTxn p/99272758 amt/5.5` returns all transactions with the person `Bernice Yu` with amount `5.50`.<br>
-![result for 'filterTxn p/99272758 amt/5.5'](images/filterTxnBerniceYuAmt55Result.png)
+  ![result for 'filterTxn p/99272758 amt/5.5'](images/filterTxnBerniceYuAmt55Result.png)
 
 ### Adding Remarks for a person : `remark`
 
@@ -228,6 +231,28 @@ Format: `clear`
 Clears all entries from the transaction book.
 
 Format: `clearTxn`
+
+### Editing a transaction : `editTxn `
+
+Edits an existing transaction in the transaction book.
+
+Format: `editTxn [INDEX] [p/PHONE_NUMBER] [amt/AMOUNT] [desc/TEST] [date/DATE] [cat/CATEGORY]...`
+
+* Edits the transaction at the specified `INDEX`. The index refers to the index number shown in the displayed person
+  list.
+  The index **must be a positive integer** 1, 2, 3, …​
+* At least one of the optional fields must be provided.
+* Existing values will be updated to the input values.
+* When editing categories, the existing categories of the person will be removed i.e adding of categories is not
+  cumulative.
+* You can remove all the person’s categories by typing `cat/` without
+  specifying any categories after it.
+
+Examples:
+
+* `editTxn 1 p/91234567 desc/Hello world` Edits the phone number and description of the 1st transaction to be `91234567`
+  and `Hello world` respectively.
+* `editTxn 2 cat/` Edits the 2nd transaction by removing all existing categories.
 
 ### Exiting the program : `exit`
 
@@ -292,9 +317,10 @@ the data of your previous AddressBook home folder.
 
 ## Command Summary for Transactions
 
-| Action     | Format, Examples                                                                                                                                                                   |
-|------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **Add**    | `add p/PHONE_NUMBER amt/AMOUNT desc/DESCRIPTION [date/DATE]` <br> e.g., `addTxn p/99999999 amt/-9999999999.99 desc/Sean owes me a lot for a plot of land in sentosa date/10102024` |
-| **List**   | `listTxn`                                                                                                                                                                          |
-| **Filter** | `filterTxn [p/PHONE_NUMBER] [amt/AMOUNT] [desc/DESCRIPTION] [date/DATE]` <br> e.g. `filterTxn p/99999999`                                                                          |
-| **Clear**  | `clearTxn`                                                                                                                                                                         |
+| Action     | Format, Examples                                                                                                                                                                                |
+|------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Add**    | `addTxn p/PHONE_NUMBER amt/AMOUNT desc/DESCRIPTION [date/DATE]` <br> e.g., `addTxn p/99999999 amt/-9999999999.99 desc/Sean owes me a lot for a plot of land in sentosa date/10102024`           |
+| **Edit**   | `editTxn INDEX p/PHONE_NUMBER amt/AMOUNT desc/DESCRIPTION [date/DATE]` <br> e.g., `editTxn 1 p/99999999 amt/-9999999999.99 desc/Sean owes me a lot for a plot of land in sentosa date/10102024` |
+| **List**   | `listTxn`                                                                                                                                                                                       |
+| **Filter** | `filterTxn [p/PHONE_NUMBER] [amt/AMOUNT] [desc/DESCRIPTION] [date/DATE]` <br> e.g. `filterTxn p/99999999`                                                                                       |
+| **Clear**  | `clearTxn`                                                                                                                                                                                      |

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -104,7 +104,7 @@ Format: `addTxn p/PHONE_NUMBER amt/AMOUNT desc/TEST [date/DATE] [cat/CATEGORY]..
 * The `AMOUNT` accepts a decimal number with up to 2 decimal places. A `-` can be added as prefix to indicate negative
   amount.
 * The `DATE` accepts date formatted in the form `DDMMYYYY` i.e.`10102024`.
-* The `CATEOGORY` accepts any non-empty string.
+* The `CATEGORY` accepts non-empty strings that are alphanumeric with spaces.
 
 :bulb: **Tip:** If the transaction happened on the current day, the date parameter can be omitted.
 :bulb: **Tip:** A person can have any number of categories (including 0)

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -98,12 +98,13 @@ Examples:
 
 Adds a transaction to the transaction book.
 
-Format: `addTxn [p/PHONE_NUMBER] [amt/AMOUNT] [desc/TEST] [date/DATE] [cat/CATEGORY]...`
+Format: `addTxn p/PHONE_NUMBER amt/AMOUNT desc/TEST [date/DATE] [cat/CATEGORY]...`
 
 * The `PHONE_NUMBER` refers to the phone number associated to the person had a transaction with.
 * The `AMOUNT` accepts a decimal number with up to 2 decimal places. A `-` can be added as prefix to indicate negative
   amount.
 * The `DATE` accepts date formatted in the form `DDMMYYYY` i.e.`10102024`.
+* The `CATEOGORY` accepts any non-empty string.
 
 :bulb: **Tip:** If the transaction happened on the current day, the date parameter can be omitted.
 :bulb: **Tip:** A person can have any number of categories (including 0)
@@ -317,10 +318,10 @@ the data of your previous AddressBook home folder.
 
 ## Command Summary for Transactions
 
-| Action     | Format, Examples                                                                                                                                                                                |
-|------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **Add**    | `addTxn p/PHONE_NUMBER amt/AMOUNT desc/DESCRIPTION [date/DATE]` <br> e.g., `addTxn p/99999999 amt/-9999999999.99 desc/Sean owes me a lot for a plot of land in sentosa date/10102024`           |
-| **Edit**   | `editTxn INDEX p/PHONE_NUMBER amt/AMOUNT desc/DESCRIPTION [date/DATE]` <br> e.g., `editTxn 1 p/99999999 amt/-9999999999.99 desc/Sean owes me a lot for a plot of land in sentosa date/10102024` |
-| **List**   | `listTxn`                                                                                                                                                                                       |
-| **Filter** | `filterTxn [p/PHONE_NUMBER] [amt/AMOUNT] [desc/DESCRIPTION] [date/DATE]` <br> e.g. `filterTxn p/99999999`                                                                                       |
-| **Clear**  | `clearTxn`                                                                                                                                                                                      |
+| Action     | Format, Examples                                                                                                                                                                                         |
+|------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Add**    | `addTxn p/PHONE_NUMBER amt/AMOUNT desc/DESCRIPTION [date/DATE]` <br> e.g., `addTxn p/99999999 amt/-9999999999.99 desc/Sean owes me a lot for a plot of land in sentosa date/10102024 cat/TEST`           |
+| **Edit**   | `editTxn INDEX p/PHONE_NUMBER amt/AMOUNT desc/DESCRIPTION [date/DATE]` <br> e.g., `editTxn 1 p/99999999 amt/-9999999999.99 desc/Sean owes me a lot for a plot of land in sentosa date/10102024 cat/TEST` |
+| **List**   | `listTxn`                                                                                                                                                                                                |
+| **Filter** | `filterTxn [p/PHONE_NUMBER] [amt/AMOUNT] [desc/DESCRIPTION] [date/DATE]` <br> e.g. `filterTxn p/99999999`                                                                                                |
+| **Clear**  | `clearTxn`                                                                                                                                                                                               |

--- a/src/main/java/spleetwaise/address/model/AddressBook.java
+++ b/src/main/java/spleetwaise/address/model/AddressBook.java
@@ -6,8 +6,10 @@ import java.util.List;
 import java.util.Optional;
 
 import javafx.collections.ObservableList;
+import javafx.collections.transformation.FilteredList;
 import spleetwaise.address.commons.util.ToStringBuilder;
 import spleetwaise.address.model.person.Person;
+import spleetwaise.address.model.person.Phone;
 import spleetwaise.address.model.person.UniquePersonList;
 
 /**
@@ -20,7 +22,6 @@ public class AddressBook implements ReadOnlyAddressBook {
     /*
      * The 'unusual' code block below is a non-static initialization block, sometimes used to avoid duplication
      * between constructors. See https://docs.oracle.com/javase/tutorial/java/javaOO/initial.html
-     *
      * Note that non-static init blocks are not recommended to use. There are other ways to avoid duplication
      *   among constructors.
      */
@@ -63,6 +64,16 @@ public class AddressBook implements ReadOnlyAddressBook {
     public Optional<Person> getPersonById(String id) {
         requireNonNull(id);
         return persons.getPersonById(id);
+    }
+
+    public Optional<Person> getPersonByPhone(Phone phone) {
+        requireNonNull(phone);
+
+        FilteredList<Person> filteredPersonList = getPersonList().filtered((p) -> p.getPhone().equals(phone));
+        if (filteredPersonList.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(filteredPersonList.get(0));
     }
 
     /**

--- a/src/main/java/spleetwaise/address/model/AddressBookModel.java
+++ b/src/main/java/spleetwaise/address/model/AddressBookModel.java
@@ -7,6 +7,7 @@ import java.util.function.Predicate;
 import javafx.collections.ObservableList;
 import spleetwaise.address.commons.core.GuiSettings;
 import spleetwaise.address.model.person.Person;
+import spleetwaise.address.model.person.Phone;
 
 /**
  * The API of the Model component.
@@ -90,4 +91,9 @@ public interface AddressBookModel {
      * Searches for a person with the given ID
      */
     Optional<Person> getPersonById(String id);
+
+    /**
+     * Searches for a person with the given Phone
+     */
+    Optional<Person> getPersonByPhone(Phone phone);
 }

--- a/src/main/java/spleetwaise/address/model/AddressBookModelManager.java
+++ b/src/main/java/spleetwaise/address/model/AddressBookModelManager.java
@@ -13,6 +13,7 @@ import javafx.collections.transformation.FilteredList;
 import spleetwaise.address.commons.core.GuiSettings;
 import spleetwaise.address.commons.core.LogsCenter;
 import spleetwaise.address.model.person.Person;
+import spleetwaise.address.model.person.Phone;
 
 /**
  * Represents the in-memory model of the address book data.
@@ -136,6 +137,12 @@ public class AddressBookModelManager implements AddressBookModel {
     public Optional<Person> getPersonById(String id) {
         requireNonNull(id);
         return addressBook.getPersonById(id);
+    }
+
+    @Override
+    public Optional<Person> getPersonByPhone(Phone phone) {
+        requireNonNull(phone);
+        return addressBook.getPersonByPhone(phone);
     }
 
     @Override

--- a/src/main/java/spleetwaise/commons/model/CommonModel.java
+++ b/src/main/java/spleetwaise/commons/model/CommonModel.java
@@ -1,6 +1,7 @@
 package spleetwaise.commons.model;
 
 import static java.util.Objects.requireNonNull;
+import static spleetwaise.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.nio.file.Path;
 import java.util.Optional;
@@ -12,6 +13,7 @@ import spleetwaise.address.model.AddressBookModel;
 import spleetwaise.address.model.ReadOnlyAddressBook;
 import spleetwaise.address.model.ReadOnlyUserPrefs;
 import spleetwaise.address.model.person.Person;
+import spleetwaise.address.model.person.Phone;
 import spleetwaise.transaction.model.ReadOnlyTransactionBook;
 import spleetwaise.transaction.model.TransactionBookModel;
 import spleetwaise.transaction.model.transaction.Transaction;
@@ -144,6 +146,13 @@ public class CommonModel implements Model {
         return addressBookModel.getPersonById(id);
     }
 
+    @Override
+    public Optional<Person> getPersonByPhone(Phone phone) {
+        requireNonNull(addressBookModel, "AddressBook model cannot be null");
+        requireNonNull(phone);
+        return addressBookModel.getPersonByPhone(phone);
+    }
+
     // TransactionBook
     @Override
     public ReadOnlyTransactionBook getTransactionBook() {
@@ -191,5 +200,12 @@ public class CommonModel implements Model {
     public void deleteTransaction(Transaction target) {
         requireNonNull(transactionBookModel, "TransactionBook model cannot be null");
         transactionBookModel.deleteTransaction(target);
+    }
+
+    @Override
+    public void setTransaction(Transaction target, Transaction editedTransaction) {
+        requireNonNull(transactionBookModel, "TransactionBook model cannot be null");
+        requireAllNonNull(target, editedTransaction);
+        transactionBookModel.setTransaction(target, editedTransaction);
     }
 }

--- a/src/main/java/spleetwaise/transaction/logic/commands/EditCommand.java
+++ b/src/main/java/spleetwaise/transaction/logic/commands/EditCommand.java
@@ -159,7 +159,9 @@ public class EditCommand extends Command {
             setAmount(toCopy.amount);
             setDescription(toCopy.description);
             setDate(toCopy.date);
-            setCategories(new HashSet<>(toCopy.categories));
+            if (toCopy.categories != null) {
+                setCategories(new HashSet<>(toCopy.categories));
+            }
         }
 
         /**

--- a/src/main/java/spleetwaise/transaction/logic/commands/EditCommand.java
+++ b/src/main/java/spleetwaise/transaction/logic/commands/EditCommand.java
@@ -1,0 +1,257 @@
+package spleetwaise.transaction.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static spleetwaise.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static spleetwaise.transaction.logic.parser.CliSyntax.PREFIX_AMOUNT;
+import static spleetwaise.transaction.logic.parser.CliSyntax.PREFIX_CATEGORY;
+import static spleetwaise.transaction.logic.parser.CliSyntax.PREFIX_DATE;
+import static spleetwaise.transaction.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+import spleetwaise.address.commons.core.index.Index;
+import spleetwaise.address.commons.util.CollectionUtil;
+import spleetwaise.address.commons.util.ToStringBuilder;
+import spleetwaise.address.model.person.Person;
+import spleetwaise.commons.logic.commands.Command;
+import spleetwaise.commons.logic.commands.CommandResult;
+import spleetwaise.commons.logic.commands.exceptions.CommandException;
+import spleetwaise.commons.model.CommonModel;
+import spleetwaise.transaction.logic.Messages;
+import spleetwaise.transaction.model.TransactionBookModel;
+import spleetwaise.transaction.model.transaction.Amount;
+import spleetwaise.transaction.model.transaction.Category;
+import spleetwaise.transaction.model.transaction.Date;
+import spleetwaise.transaction.model.transaction.Description;
+import spleetwaise.transaction.model.transaction.Transaction;
+
+/**
+ * Edits the details of an existing transaction in the transaction book.
+ */
+public class EditCommand extends Command {
+
+    public static final String COMMAND_WORD = "editTxn";
+
+    /**
+     * The message usage string that explains how to use this command.
+     */
+    public static final String MESSAGE_USAGE =
+            COMMAND_WORD + ": Edit a transaction.\n" + "Parameters: " + " INDEX (must be a positive integer) "
+                    + PREFIX_PHONE + "CONTACT " + PREFIX_AMOUNT
+                    + "AMOUNT " + PREFIX_DESCRIPTION + "DESCRIPTION " + "[" + PREFIX_DATE + "DATE ]" + PREFIX_CATEGORY
+                    + "FOOD\n" + "Example: " + COMMAND_WORD + " " + PREFIX_PHONE + "88888888 " + PREFIX_AMOUNT
+                    + "10.00 " + PREFIX_DESCRIPTION + "Paid John for lunch" + PREFIX_DATE + "23012024 "
+                    + PREFIX_CATEGORY + "FOOD";
+
+
+    public static final String MESSAGE_EDIT_TXN_SUCCESS = "Edited Transaction: %1$s";
+    public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
+    public static final String MESSAGE_DUPLICATE_TXN = "This transaction already exists in the transaction book.";
+
+
+    private final Index index;
+    private final EditTransactionDescriptor editTransactionDescriptor;
+
+    /**
+     * @param index                     of the transaction in the filtered txn list to edit
+     * @param editTransactionDescriptor details to edit the txn with
+     */
+    public EditCommand(Index index, EditTransactionDescriptor editTransactionDescriptor) {
+        requireNonNull(index);
+        requireNonNull(editTransactionDescriptor);
+
+        this.index = index;
+        this.editTransactionDescriptor = editTransactionDescriptor;
+    }
+
+    /**
+     * Creates and returns a {@code Transaction} with the details of {@code transctionToEdit} edited with
+     * {@code editTransactionDescriptor}.
+     */
+    private static Transaction createEditedTransaction(
+            Transaction txnToEdit,
+            EditTransactionDescriptor editTransactionDescriptor
+    ) {
+        requireNonNull(txnToEdit);
+
+        String id = editTransactionDescriptor.getId().orElse(txnToEdit.getId());
+        Person person = editTransactionDescriptor.getPerson().orElse(txnToEdit.getPerson());
+        Amount amount = editTransactionDescriptor.getAmount().orElse(txnToEdit.getAmount());
+        Description description = editTransactionDescriptor.getDescription().orElse(txnToEdit.getDescription());
+        Date date = editTransactionDescriptor.getDate().orElse(txnToEdit.getDate());
+        Set<Category> categories = editTransactionDescriptor.getCategories().orElse(txnToEdit.getCategories());
+
+        return new Transaction(id, person, amount, description, date, categories);
+    }
+
+    public EditTransactionDescriptor getDescriptor() {
+        return editTransactionDescriptor;
+    }
+
+    @Override
+    public CommandResult execute() throws CommandException {
+        CommonModel model = CommonModel.getInstance();
+        List<Transaction> lastShownList = model.getFilteredTransactionList();
+
+        if (index.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_TRANSACTION_DISPLAYED_INDEX);
+        }
+
+        Transaction txnToEdit = lastShownList.get(index.getZeroBased());
+        Transaction editedTxn = createEditedTransaction(txnToEdit, editTransactionDescriptor);
+
+        if (!txnToEdit.equals(editedTxn) && model.hasTransaction(editedTxn)) {
+            throw new CommandException(MESSAGE_DUPLICATE_TXN);
+        }
+
+        model.setTransaction(txnToEdit, editedTxn);
+        model.updateFilteredTransactionList(TransactionBookModel.PREDICATE_SHOW_ALL_TXNS);
+        return new CommandResult(String.format(MESSAGE_EDIT_TXN_SUCCESS, editedTxn));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof EditCommand otherEditCommand)) {
+            return false;
+        }
+
+        return index.equals(otherEditCommand.index)
+                && editTransactionDescriptor.equals(otherEditCommand.editTransactionDescriptor);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).add("index", index).add(
+                "editTransactionDescriptor",
+                editTransactionDescriptor
+        ).toString();
+    }
+
+    /**
+     * Represents the data of a transaction that can be edited.
+     */
+    public static class EditTransactionDescriptor {
+        private String id;
+        private Person person;
+        private Amount amount;
+        private Description description;
+        private Date date;
+        private Set<Category> categories;
+
+        public EditTransactionDescriptor() {
+        }
+
+        /**
+         * Copy constructor. A defensive copy of {@code categories} is used internally.
+         */
+        public EditTransactionDescriptor(EditTransactionDescriptor toCopy) {
+            setId(toCopy.id);
+            setPerson(toCopy.person);
+            setAmount(toCopy.amount);
+            setDescription(toCopy.description);
+            setDate(toCopy.date);
+            setCategories(new HashSet<>(toCopy.categories));
+        }
+
+        /**
+         * Returns true if at least one field is edited.
+         */
+        public boolean isAnyFieldEdited() {
+            return CollectionUtil.isAnyNonNull(person, amount, description, date, categories);
+        }
+
+        public Optional<String> getId() {
+            return Optional.ofNullable(id);
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public Optional<Person> getPerson() {
+            return Optional.ofNullable(person);
+        }
+
+        public void setPerson(Person person) {
+            this.person = person;
+        }
+
+        public Optional<Amount> getAmount() {
+            return Optional.ofNullable(amount);
+        }
+
+        public void setAmount(Amount amount) {
+            this.amount = amount;
+        }
+
+        public Optional<Description> getDescription() {
+            return Optional.ofNullable(description);
+        }
+
+        public void setDescription(Description description) {
+            this.description = description;
+        }
+
+        public Optional<Date> getDate() {
+            return Optional.ofNullable(date);
+        }
+
+        public void setDate(Date date) {
+            this.date = date;
+        }
+
+        /**
+         * Returns an unmodifiable category set, which throws {@code UnsupportedOperationException} if modification is
+         * attempted. Returns {@code Optional#empty()} if {@code categories} is null.
+         */
+        public Optional<Set<Category>> getCategories() {
+            return (categories != null) ? Optional.of(Collections.unmodifiableSet(categories)) : Optional.empty();
+        }
+
+        public void setCategories(Set<Category> categories) {
+            this.categories = new HashSet<>(categories);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (other == this) {
+                return true;
+            }
+
+            // instanceof handles nulls
+            if (!(other instanceof EditTransactionDescriptor otherEditTransactionDescriptor)) {
+                return false;
+            }
+
+            return Objects.equals(id, otherEditTransactionDescriptor.id)
+                    && Objects.equals(person, otherEditTransactionDescriptor.person)
+                    && Objects.equals(amount, otherEditTransactionDescriptor.amount)
+                    && Objects.equals(description, otherEditTransactionDescriptor.description)
+                    && Objects.equals(date, otherEditTransactionDescriptor.date)
+                    && Objects.equals(categories, otherEditTransactionDescriptor.categories);
+        }
+
+        @Override
+        public String toString() {
+            return new ToStringBuilder(this)
+                    .add("id", id)
+                    .add("person", person)
+                    .add("amount", amount)
+                    .add("description", description)
+                    .add("date", date)
+                    .add("categories", categories)
+                    .toString();
+        }
+    }
+
+
+}

--- a/src/main/java/spleetwaise/transaction/logic/parser/EditCommandParser.java
+++ b/src/main/java/spleetwaise/transaction/logic/parser/EditCommandParser.java
@@ -1,0 +1,99 @@
+package spleetwaise.transaction.logic.parser;
+
+import static spleetwaise.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static spleetwaise.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static spleetwaise.address.logic.parser.ParserUtil.parsePhone;
+import static spleetwaise.transaction.logic.commands.EditCommand.MESSAGE_USAGE;
+import static spleetwaise.transaction.logic.parser.CliSyntax.PREFIX_AMOUNT;
+import static spleetwaise.transaction.logic.parser.CliSyntax.PREFIX_CATEGORY;
+import static spleetwaise.transaction.logic.parser.CliSyntax.PREFIX_DATE;
+import static spleetwaise.transaction.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
+
+import java.util.Set;
+import java.util.stream.Stream;
+
+import spleetwaise.address.commons.core.index.Index;
+import spleetwaise.address.logic.parser.ArgumentMultimap;
+import spleetwaise.address.logic.parser.ArgumentTokenizer;
+import spleetwaise.address.logic.parser.Prefix;
+import spleetwaise.address.model.person.Phone;
+import spleetwaise.commons.logic.parser.Parser;
+import spleetwaise.commons.logic.parser.exceptions.ParseException;
+import spleetwaise.transaction.logic.commands.EditCommand;
+import spleetwaise.transaction.logic.commands.EditCommand.EditTransactionDescriptor;
+import spleetwaise.transaction.model.transaction.Amount;
+import spleetwaise.transaction.model.transaction.Category;
+import spleetwaise.transaction.model.transaction.Date;
+import spleetwaise.transaction.model.transaction.Description;
+
+
+/**
+ * Parses input arguments and creates a new EditCommand object
+ */
+public class EditCommandParser implements Parser<EditCommand> {
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+
+    @Override
+    public EditCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(
+                        args, PREFIX_PHONE, PREFIX_AMOUNT, PREFIX_DESCRIPTION, PREFIX_DATE, PREFIX_CATEGORY);
+
+        // Parse index
+        Index index;
+        try {
+            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+        } catch (ParseException e) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE), e);
+        }
+
+        // Parse descriptors
+        argMultimap.verifyNoDuplicatePrefixesFor(
+                PREFIX_PHONE, PREFIX_AMOUNT, PREFIX_DESCRIPTION, PREFIX_DATE, PREFIX_CATEGORY);
+
+        EditTransactionDescriptor editTransactionDescriptor = new EditTransactionDescriptor();
+
+        if (argMultimap.getValue(PREFIX_PHONE).isPresent()) {
+            Phone phone = parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
+            editTransactionDescriptor.setPerson(ParserUtil.getPersonFromPhone(phone));
+        }
+
+        if (argMultimap.getValue(PREFIX_AMOUNT).isPresent()) {
+            Amount amount = ParserUtil.parseAmount(argMultimap.getValue(PREFIX_AMOUNT).get());
+            editTransactionDescriptor.setAmount(amount);
+        }
+
+        if (argMultimap.getValue(PREFIX_DESCRIPTION).isPresent()) {
+            Description desc = ParserUtil.parseDescription(argMultimap.getValue(PREFIX_DESCRIPTION).get());
+            editTransactionDescriptor.setDescription(desc);
+        }
+
+        if (argMultimap.getValue(PREFIX_DATE).isPresent()) {
+            Date date = ParserUtil.parseDate(argMultimap.getValue(PREFIX_DATE).get());
+            editTransactionDescriptor.setDate(date);
+        }
+
+        if (!argMultimap.getAllValues(PREFIX_CATEGORY).isEmpty()) {
+            Set<Category> categoriesSet = ParserUtil.parseCategories(argMultimap.getAllValues(PREFIX_CATEGORY));
+            if (!categoriesSet.isEmpty()) {
+                editTransactionDescriptor.setCategories(categoriesSet);
+            }
+        }
+
+        // Check if any fields edited
+        if (!editTransactionDescriptor.isAnyFieldEdited()) {
+            throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);
+        }
+
+        return new EditCommand(index, editTransactionDescriptor);
+
+    }
+
+}

--- a/src/main/java/spleetwaise/transaction/logic/parser/ParserUtil.java
+++ b/src/main/java/spleetwaise/transaction/logic/parser/ParserUtil.java
@@ -4,13 +4,11 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 
-import javafx.collections.ObservableList;
-import javafx.collections.transformation.FilteredList;
 import spleetwaise.address.commons.core.index.Index;
 import spleetwaise.address.commons.util.StringUtil;
-import spleetwaise.address.model.ReadOnlyAddressBook;
 import spleetwaise.address.model.person.Person;
 import spleetwaise.address.model.person.Phone;
 import spleetwaise.commons.logic.parser.exceptions.ParseException;
@@ -26,6 +24,7 @@ import spleetwaise.transaction.model.transaction.Description;
 public class ParserUtil {
 
     public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
+    public static final String MESSAGE_UNKOWN_PHONE_NUMBER = "Phone number is unknown.";
 
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
@@ -118,12 +117,10 @@ public class ParserUtil {
      */
     public static Person getPersonFromPhone(Phone phone) throws ParseException {
         requireNonNull(phone);
-        ReadOnlyAddressBook ab = CommonModel.getInstance().getAddressBook();
-        ObservableList<Person> personList = ab.getPersonList();
-        FilteredList<Person> filteredPersonList = personList.filtered((p) -> p.getPhone().equals(phone));
-        if (filteredPersonList.isEmpty()) {
-            throw new ParseException(Phone.MESSAGE_CONSTRAINTS);
+        Optional<Person> p = CommonModel.getInstance().getPersonByPhone(phone);
+        if (p.isEmpty()) {
+            throw new ParseException(MESSAGE_UNKOWN_PHONE_NUMBER);
         }
-        return filteredPersonList.get(0);
+        return p.get();
     }
 }

--- a/src/main/java/spleetwaise/transaction/logic/parser/ParserUtil.java
+++ b/src/main/java/spleetwaise/transaction/logic/parser/ParserUtil.java
@@ -24,7 +24,7 @@ import spleetwaise.transaction.model.transaction.Description;
 public class ParserUtil {
 
     public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
-    public static final String MESSAGE_UNKOWN_PHONE_NUMBER = "Phone number is unknown.";
+    public static final String MESSAGE_PHONE_NUMBER_IS_UNKNOWN = "Phone number is unknown.";
 
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
@@ -119,7 +119,7 @@ public class ParserUtil {
         requireNonNull(phone);
         Optional<Person> p = CommonModel.getInstance().getPersonByPhone(phone);
         if (p.isEmpty()) {
-            throw new ParseException(MESSAGE_UNKOWN_PHONE_NUMBER);
+            throw new ParseException(MESSAGE_PHONE_NUMBER_IS_UNKNOWN);
         }
         return p.get();
     }

--- a/src/main/java/spleetwaise/transaction/logic/parser/TransactionParser.java
+++ b/src/main/java/spleetwaise/transaction/logic/parser/TransactionParser.java
@@ -10,6 +10,7 @@ import spleetwaise.commons.logic.parser.exceptions.ParseException;
 import spleetwaise.transaction.logic.commands.AddCommand;
 import spleetwaise.transaction.logic.commands.ClearCommand;
 import spleetwaise.transaction.logic.commands.DeleteCommand;
+import spleetwaise.transaction.logic.commands.EditCommand;
 import spleetwaise.transaction.logic.commands.FilterCommand;
 import spleetwaise.transaction.logic.commands.ListCommand;
 
@@ -57,6 +58,8 @@ public class TransactionParser {
             return new FilterCommandParser().parse(arguments);
         case DeleteCommand.COMMAND_WORD:
             return new DeleteCommandParser().parse(arguments);
+        case EditCommand.COMMAND_WORD:
+            return new EditCommandParser().parse(arguments);
         default:
             return null;
         }

--- a/src/main/java/spleetwaise/transaction/model/TransactionBook.java
+++ b/src/main/java/spleetwaise/transaction/model/TransactionBook.java
@@ -72,7 +72,7 @@ public class TransactionBook implements ReadOnlyTransactionBook {
      *
      * @param replacementTransactionBook The data used to replace the current transactions.
      */
-    public void setTransactions(ReadOnlyTransactionBook replacementTransactionBook) {
+    public void setTransactionBook(ReadOnlyTransactionBook replacementTransactionBook) {
         requireNonNull(replacementTransactionBook);
         transactionList.clear();
         transactionList.addAll(replacementTransactionBook.getTransactionList());

--- a/src/main/java/spleetwaise/transaction/model/TransactionBook.java
+++ b/src/main/java/spleetwaise/transaction/model/TransactionBook.java
@@ -10,6 +10,7 @@ import javafx.collections.ObservableList;
 import spleetwaise.address.commons.util.CollectionUtil;
 import spleetwaise.transaction.model.transaction.Transaction;
 import spleetwaise.transaction.model.transaction.exceptions.DuplicateTransactionException;
+import spleetwaise.transaction.model.transaction.exceptions.TransactionNotFoundException;
 
 /**
  * Wraps all data at the transaction book level.
@@ -79,6 +80,24 @@ public class TransactionBook implements ReadOnlyTransactionBook {
     }
 
     /**
+     * Replaces the transaction {@code target} in the list with {@code replacement}. {@code target} must exist in the
+     * list. The txn identity of {@code replacement} must not be the same as another existing txn in the list.
+     */
+    public void setTransaction(Transaction target, Transaction replacement) {
+        CollectionUtil.requireAllNonNull(target, replacement);
+        int i = transactionList.indexOf(target);
+        if (i == -1) {
+            throw new TransactionNotFoundException();
+        }
+
+        if (!target.equals(replacement) && containsTransaction(replacement)) {
+            throw new DuplicateTransactionException();
+        }
+
+        transactionList.set(i, replacement);
+    }
+
+    /**
      * Adds a transaction entry to the transaction list.
      *
      * @param transaction The transaction to be added.
@@ -98,6 +117,7 @@ public class TransactionBook implements ReadOnlyTransactionBook {
      * @return whether the removal was successful
      */
     public boolean removeTransaction(Transaction key) {
+        requireNonNull(key);
         return transactionList.remove(key);
     }
 

--- a/src/main/java/spleetwaise/transaction/model/TransactionBookModel.java
+++ b/src/main/java/spleetwaise/transaction/model/TransactionBookModel.java
@@ -52,4 +52,9 @@ public interface TransactionBookModel {
      * Deletes the given transaction. Transaction must be present in the transactionBook.
      */
     void deleteTransaction(Transaction target);
+
+    /**
+     * Replaces the given transaction. Transaction must be present in the transactionBook.
+     */
+    void setTransaction(Transaction target, Transaction editedTransaction);
 }

--- a/src/main/java/spleetwaise/transaction/model/TransactionBookModelManager.java
+++ b/src/main/java/spleetwaise/transaction/model/TransactionBookModelManager.java
@@ -1,6 +1,7 @@
 package spleetwaise.transaction.model;
 
 import static java.util.Objects.requireNonNull;
+import static spleetwaise.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.function.Predicate;
 import java.util.logging.Logger;
@@ -92,6 +93,13 @@ public class TransactionBookModelManager implements TransactionBookModel {
         requireNonNull(transaction);
         transactionBook.removeTransaction(transaction);
         updateFilteredTransactionList(PREDICATE_SHOW_ALL_TXNS);
+    }
+
+    @Override
+    public void setTransaction(Transaction target, Transaction editedTransaction) {
+        requireAllNonNull(target, editedTransaction);
+
+        transactionBook.setTransaction(target, editedTransaction);
     }
 
     @Override

--- a/src/main/java/spleetwaise/transaction/model/TransactionBookModelManager.java
+++ b/src/main/java/spleetwaise/transaction/model/TransactionBookModelManager.java
@@ -56,7 +56,7 @@ public class TransactionBookModelManager implements TransactionBookModel {
     @Override
     public void setTransactionBook(ReadOnlyTransactionBook replacementBook) {
         requireNonNull(replacementBook);
-        transactionBook.setTransactions(replacementBook);
+        transactionBook.setTransactionBook(replacementBook);
     }
 
     @Override

--- a/src/main/java/spleetwaise/transaction/model/transaction/exceptions/TransactionNotFoundException.java
+++ b/src/main/java/spleetwaise/transaction/model/transaction/exceptions/TransactionNotFoundException.java
@@ -1,0 +1,7 @@
+package spleetwaise.transaction.model.transaction.exceptions;
+
+/**
+ * Signals that the operation is unable to find the specified transaction.
+ */
+public class TransactionNotFoundException extends RuntimeException {
+}

--- a/src/test/java/spleetwaise/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/spleetwaise/address/logic/commands/AddCommandTest.java
@@ -21,6 +21,7 @@ import spleetwaise.address.model.AddressBookModel;
 import spleetwaise.address.model.ReadOnlyAddressBook;
 import spleetwaise.address.model.ReadOnlyUserPrefs;
 import spleetwaise.address.model.person.Person;
+import spleetwaise.address.model.person.Phone;
 import spleetwaise.address.testutil.Assert;
 import spleetwaise.address.testutil.PersonBuilder;
 import spleetwaise.address.testutil.TypicalPersons;
@@ -168,6 +169,11 @@ public class AddCommandTest {
 
         @Override
         public Optional<Person> getPersonById(String id) {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<Person> getPersonByPhone(Phone phone) {
             return Optional.empty();
         }
     }

--- a/src/test/java/spleetwaise/transaction/logic/commands/EditCommandTest.java
+++ b/src/test/java/spleetwaise/transaction/logic/commands/EditCommandTest.java
@@ -1,0 +1,163 @@
+package spleetwaise.transaction.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import spleetwaise.address.commons.core.index.Index;
+import spleetwaise.address.model.AddressBookModel;
+import spleetwaise.address.model.AddressBookModelManager;
+import spleetwaise.address.model.UserPrefs;
+import spleetwaise.address.testutil.TypicalPersons;
+import spleetwaise.commons.model.CommonModel;
+import spleetwaise.transaction.logic.Messages;
+import spleetwaise.transaction.logic.commands.EditCommand.EditTransactionDescriptor;
+import spleetwaise.transaction.model.TransactionBookModel;
+import spleetwaise.transaction.model.TransactionBookModelManager;
+import spleetwaise.transaction.model.transaction.Description;
+import spleetwaise.transaction.model.transaction.Transaction;
+import spleetwaise.transaction.testutil.TransactionBuilder;
+import spleetwaise.transaction.testutil.TypicalIndexes;
+import spleetwaise.transaction.testutil.TypicalTransactions;
+
+public class EditCommandTest {
+    private final TransactionBookModel tbModel = new TransactionBookModelManager(
+            TypicalTransactions.getTypicalTransactionBook());
+    private final AddressBookModel abModel = new AddressBookModelManager(
+            TypicalPersons.getTypicalAddressBook(), new UserPrefs());
+
+    @BeforeEach
+    void setUp() {
+        CommonModel.initialise(abModel, tbModel);
+    }
+
+    @Test
+    public void execute_validEditTransaction_success() {
+        Transaction editedTransaction = new TransactionBuilder().build();
+        EditTransactionDescriptor descriptor = new EditTransactionDescriptor(buildDescriptor(editedTransaction));
+        EditCommand editCommand = new EditCommand(TypicalIndexes.INDEX_FIRST_TRANSACTION, descriptor);
+
+        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_TXN_SUCCESS, editedTransaction);
+
+        TransactionBookModel expectedModel = new TransactionBookModelManager(tbModel.getTransactionBook());
+        expectedModel.setTransaction(
+                expectedModel.getFilteredTransactionList().get(TypicalIndexes.INDEX_FIRST_TRANSACTION.getZeroBased()),
+                editedTransaction
+        );
+
+        CommandTestUtil.assertCommandSuccess(editCommand, tbModel, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_emptyEditTransaction_success() {
+        EditTransactionDescriptor descriptor = new EditTransactionDescriptor();
+        EditCommand editCommand = new EditCommand(TypicalIndexes.INDEX_FIRST_TRANSACTION, descriptor);
+
+        String expectedMessage = String.format(
+                EditCommand.MESSAGE_EDIT_TXN_SUCCESS,
+                tbModel.getFilteredTransactionList().get(0)
+        );
+
+        TransactionBookModel expectedModel = new TransactionBookModelManager(tbModel.getTransactionBook());
+
+        CommandTestUtil.assertCommandSuccess(editCommand, tbModel, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_duplicateEditTransaction_failure() {
+        Transaction editedTransaction =
+                tbModel.getFilteredTransactionList().get(TypicalIndexes.INDEX_SECOND_TRANSACTION.getZeroBased());
+
+        EditTransactionDescriptor descriptor = new EditTransactionDescriptor(buildDescriptor(editedTransaction));
+        EditCommand editCommand = new EditCommand(TypicalIndexes.INDEX_FIRST_TRANSACTION, descriptor);
+
+        String expectedMessage = String.format(EditCommand.MESSAGE_DUPLICATE_TXN, editedTransaction);
+
+        CommandTestUtil.assertCommandFailure(editCommand, tbModel, expectedMessage);
+    }
+
+    @Test
+    public void execute_invalidIndexEditTransaction_failure() {
+        Index invalidIndex = Index.fromZeroBased(tbModel.getFilteredTransactionList().size());
+        EditTransactionDescriptor descriptor = new EditTransactionDescriptor();
+
+        EditCommand editCommand = new EditCommand(invalidIndex, descriptor);
+
+        String expectedMessage = String.format(Messages.MESSAGE_INVALID_TRANSACTION_DISPLAYED_INDEX);
+
+        CommandTestUtil.assertCommandFailure(editCommand, tbModel, expectedMessage);
+    }
+
+    @Test
+    public void execute_invalidFilteredListIndexEditTransaction_failure() {
+        CommandTestUtil.showTransactionAtIndex(tbModel, TypicalIndexes.INDEX_FIRST_TRANSACTION);
+
+        Index invalidIndex = TypicalIndexes.INDEX_SECOND_TRANSACTION;
+        assert invalidIndex.getZeroBased() < tbModel.getTransactionBook().getTransactionList().size();
+
+        EditTransactionDescriptor descriptor = new EditTransactionDescriptor();
+
+        EditCommand editCommand = new EditCommand(invalidIndex, descriptor);
+
+        String expectedMessage = String.format(Messages.MESSAGE_INVALID_TRANSACTION_DISPLAYED_INDEX);
+
+        CommandTestUtil.assertCommandFailure(editCommand, tbModel, expectedMessage);
+    }
+
+    @Test
+    public void equals() {
+        final EditTransactionDescriptor someDescriptor = new EditTransactionDescriptor();
+        someDescriptor.setDescription(new Description("foo"));
+        final EditCommand someEditCommand = new EditCommand(
+                TypicalIndexes.INDEX_FIRST_TRANSACTION, someDescriptor);
+
+        // same values -> true
+        EditTransactionDescriptor clonedDescriptor = new EditTransactionDescriptor(someEditCommand.getDescriptor());
+        EditCommand anotherCommand = new EditCommand(TypicalIndexes.INDEX_FIRST_TRANSACTION, clonedDescriptor);
+        assertEquals(someEditCommand, anotherCommand);
+
+        // same object -> true
+        assertEquals(someEditCommand, someEditCommand);
+
+        // null -> false
+        assertNotEquals(null, someEditCommand);
+
+        // different type -> false
+        assertNotEquals(someEditCommand, new ListCommand());
+
+        // different index -> false
+        assertNotEquals(someEditCommand, new EditCommand(TypicalIndexes.INDEX_SECOND_TRANSACTION, clonedDescriptor));
+
+        // different descriptor -> false
+        clonedDescriptor.setDescription(new Description("foo2"));
+        assertNotEquals(someEditCommand, new EditCommand(TypicalIndexes.INDEX_FIRST_TRANSACTION, clonedDescriptor));
+    }
+
+    @Test
+    public void toStringMethod() {
+        Index index = Index.fromOneBased(1);
+        EditTransactionDescriptor
+                descriptor = new EditTransactionDescriptor();
+        EditCommand editCommand = new EditCommand(index, descriptor);
+        String expected = EditCommand.class.getCanonicalName() + "{index=" + index
+                + ", editTransactionDescriptor="
+                + descriptor
+                + "}";
+        assertEquals(expected, editCommand.toString());
+    }
+
+    private EditTransactionDescriptor buildDescriptor(Transaction transactionToEdit) {
+        EditTransactionDescriptor descriptor = new EditTransactionDescriptor();
+        descriptor.setId(transactionToEdit.getId());
+        descriptor.setPerson(transactionToEdit.getPerson());
+        descriptor.setAmount(transactionToEdit.getAmount());
+        descriptor.setDescription(transactionToEdit.getDescription());
+        descriptor.setDate(transactionToEdit.getDate());
+        descriptor.setCategories(transactionToEdit.getCategories());
+
+        return descriptor;
+    }
+
+}

--- a/src/test/java/spleetwaise/transaction/logic/commands/EditTransactionDescriptorTest.java
+++ b/src/test/java/spleetwaise/transaction/logic/commands/EditTransactionDescriptorTest.java
@@ -1,0 +1,82 @@
+package spleetwaise.transaction.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.HashSet;
+
+import org.junit.jupiter.api.Test;
+
+import spleetwaise.address.testutil.TypicalPersons;
+import spleetwaise.transaction.logic.commands.EditCommand.EditTransactionDescriptor;
+import spleetwaise.transaction.model.transaction.Amount;
+import spleetwaise.transaction.model.transaction.Category;
+import spleetwaise.transaction.model.transaction.Date;
+import spleetwaise.transaction.model.transaction.Description;
+
+public class EditTransactionDescriptorTest {
+
+    @Test
+    public void equals() {
+        EditTransactionDescriptor someDescriptor = new EditTransactionDescriptor();
+        someDescriptor.setPerson(TypicalPersons.ALICE);
+        someDescriptor.setAmount(new Amount("100"));
+        someDescriptor.setDescription(new Description("foo"));
+        someDescriptor.setDate(new Date("01012020"));
+        someDescriptor.setCategories(new HashSet<>(Arrays.asList(new Category("foo"))));
+
+        // same object -> true
+        assertEquals(someDescriptor, someDescriptor);
+
+        // same values -> true
+        EditTransactionDescriptor clonedDescriptor = new EditTransactionDescriptor(someDescriptor);
+        assertEquals(clonedDescriptor, someDescriptor);
+
+        assertNotEquals(someDescriptor, null);
+        assertNotEquals(someDescriptor, 3);
+
+        clonedDescriptor.setPerson(TypicalPersons.CARL);
+        assertNotEquals(someDescriptor, clonedDescriptor);
+        clonedDescriptor.setPerson(TypicalPersons.ALICE);
+
+        clonedDescriptor.setAmount(new Amount("101"));
+        assertNotEquals(someDescriptor, clonedDescriptor);
+        clonedDescriptor.setAmount(new Amount("100"));
+
+        clonedDescriptor.setDescription(new Description("foo2"));
+        assertNotEquals(someDescriptor, clonedDescriptor);
+        clonedDescriptor.setDescription(new Description("foo"));
+
+        clonedDescriptor.setDate(new Date("02012020"));
+        assertNotEquals(someDescriptor, clonedDescriptor);
+        clonedDescriptor.setDate(new Date("01012020"));
+
+        clonedDescriptor.setCategories(new HashSet<>(Arrays.asList(new Category("foo2"))));
+        assertNotEquals(someDescriptor, clonedDescriptor);
+        clonedDescriptor.setCategories(new HashSet<>(Arrays.asList(new Category("foo"))));
+    }
+
+    @Test
+    public void isAnyFieldEditedMethod() {
+        EditTransactionDescriptor editTransactionDescriptor = new EditTransactionDescriptor();
+        assertFalse(editTransactionDescriptor.isAnyFieldEdited());
+        editTransactionDescriptor.setDescription(new Description("foo"));
+        assertTrue(editTransactionDescriptor.isAnyFieldEdited());
+    }
+
+    @Test
+    public void toStringMethod() {
+        EditTransactionDescriptor editTransactionDescriptor = new EditTransactionDescriptor();
+        String expected =
+                EditTransactionDescriptor.class.getCanonicalName() + "{id=" + editTransactionDescriptor.getId()
+                        .orElse(null) + ", person=" + editTransactionDescriptor.getPerson().orElse(null) + ", amount"
+                        + "=" + editTransactionDescriptor.getAmount().orElse(null) + ", description="
+                        + editTransactionDescriptor.getDescription().orElse(null) + ", date="
+                        + editTransactionDescriptor.getDate().orElse(null) + ", categories="
+                        + editTransactionDescriptor.getCategories().orElse(null) + "}";
+        assertEquals(expected, editTransactionDescriptor.toString());
+    }
+}

--- a/src/test/java/spleetwaise/transaction/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/spleetwaise/transaction/logic/parser/AddCommandParserTest.java
@@ -63,8 +63,14 @@ public class AddCommandParserTest {
 
     @Test
     public void parse_invalidPhone_exceptionThrown() {
-        String userInput = " p/94351253 amt/1.23 desc/description date/01012024";
+        String userInput = " p/1 amt/1.23 desc/description date/01012024";
         assertParseFailure(parser, userInput, Phone.MESSAGE_CONSTRAINTS);
+    }
+
+    @Test
+    public void parse_nonExistentPhone_exceptionThrown() {
+        String userInput = " p/99999999 amt/1.23 desc/description date/01012024";
+        assertParseFailure(parser, userInput, ParserUtil.MESSAGE_UNKOWN_PHONE_NUMBER);
     }
 
     @Test

--- a/src/test/java/spleetwaise/transaction/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/spleetwaise/transaction/logic/parser/AddCommandParserTest.java
@@ -70,7 +70,7 @@ public class AddCommandParserTest {
     @Test
     public void parse_nonExistentPhone_exceptionThrown() {
         String userInput = " p/99999999 amt/1.23 desc/description date/01012024";
-        assertParseFailure(parser, userInput, ParserUtil.MESSAGE_UNKOWN_PHONE_NUMBER);
+        assertParseFailure(parser, userInput, ParserUtil.MESSAGE_PHONE_NUMBER_IS_UNKNOWN);
     }
 
     @Test

--- a/src/test/java/spleetwaise/transaction/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/spleetwaise/transaction/logic/parser/EditCommandParserTest.java
@@ -1,0 +1,151 @@
+package spleetwaise.transaction.logic.parser;
+
+import static spleetwaise.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static spleetwaise.address.testutil.Assert.assertThrows;
+import static spleetwaise.transaction.logic.parser.CliSyntax.PREFIX_AMOUNT;
+import static spleetwaise.transaction.logic.parser.CliSyntax.PREFIX_CATEGORY;
+import static spleetwaise.transaction.logic.parser.CliSyntax.PREFIX_DATE;
+import static spleetwaise.transaction.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
+
+import java.util.Arrays;
+import java.util.HashSet;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import spleetwaise.address.commons.core.index.Index;
+import spleetwaise.address.model.AddressBookModel;
+import spleetwaise.address.model.AddressBookModelManager;
+import spleetwaise.address.model.UserPrefs;
+import spleetwaise.address.model.person.Phone;
+import spleetwaise.address.testutil.TypicalPersons;
+import spleetwaise.commons.logic.parser.exceptions.ParseException;
+import spleetwaise.commons.model.CommonModel;
+import spleetwaise.transaction.logic.Messages;
+import spleetwaise.transaction.logic.commands.EditCommand;
+import spleetwaise.transaction.model.TransactionBookModel;
+import spleetwaise.transaction.model.TransactionBookModelManager;
+import spleetwaise.transaction.model.transaction.Amount;
+import spleetwaise.transaction.model.transaction.Category;
+import spleetwaise.transaction.model.transaction.Date;
+import spleetwaise.transaction.model.transaction.Description;
+import spleetwaise.transaction.testutil.TypicalTransactions;
+
+public class EditCommandParserTest {
+
+
+    private static final String MESSAGE_INVALID_FORMAT =
+            String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE);
+    private final TransactionBookModel tbModel = new TransactionBookModelManager(
+            TypicalTransactions.getTypicalTransactionBook());
+    private final AddressBookModel abModel = new AddressBookModelManager(
+            TypicalPersons.getTypicalAddressBook(), new UserPrefs());
+    private EditCommandParser parser = new EditCommandParser();
+
+
+    @BeforeEach
+    void setUp() {
+        CommonModel.initialise(abModel, tbModel);
+    }
+
+    @Test
+    public void parse_missingParts_failure() {
+        // blank
+        CommandParserTestUtil.assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
+
+        // random text
+        CommandParserTestUtil.assertParseFailure(parser, "jfjf", MESSAGE_INVALID_FORMAT);
+
+        // no fields specified
+        CommandParserTestUtil.assertParseFailure(parser, "1", EditCommand.MESSAGE_NOT_EDITED);
+        CommandParserTestUtil.assertParseFailure(parser, "1 ", EditCommand.MESSAGE_NOT_EDITED);
+    }
+
+    @Test
+    public void parse_invalidIndex_failure() {
+        CommandParserTestUtil.assertParseFailure(parser, "-1 amt/10", MESSAGE_INVALID_FORMAT);
+        CommandParserTestUtil.assertParseFailure(parser, "0 amt/10", MESSAGE_INVALID_FORMAT);
+        CommandParserTestUtil.assertParseFailure(parser, "1 dfjs", MESSAGE_INVALID_FORMAT);
+        CommandParserTestUtil.assertParseFailure(parser, "1 i/ meme", MESSAGE_INVALID_FORMAT);
+    }
+
+    @Test
+    public void parse_invalidValue_failure() {
+        // single invalid fields
+        CommandParserTestUtil.assertParseFailure(
+                parser, "1 " + PREFIX_PHONE + "notAPhoneNumber", Phone.MESSAGE_CONSTRAINTS);
+        CommandParserTestUtil.assertParseFailure(
+                parser, "1 " + PREFIX_PHONE + "12345678", ParserUtil.MESSAGE_PHONE_NUMBER_IS_UNKNOWN);
+        CommandParserTestUtil.assertParseFailure(
+                parser, "1 " + PREFIX_AMOUNT + "notAnAmount", Amount.MESSAGE_CONSTRAINTS);
+        CommandParserTestUtil.assertParseFailure(
+                parser, "1 " + PREFIX_DESCRIPTION + "", Description.MESSAGE_CONSTRAINTS);
+        CommandParserTestUtil.assertParseFailure(
+                parser, "1 " + PREFIX_DATE + "notdate", Date.MESSAGE_CONSTRAINTS);
+        // some invalid fields
+        CommandParserTestUtil.assertParseFailure(
+                parser, "1 " + PREFIX_CATEGORY + "test" + " " + PREFIX_AMOUNT + "10.0001",
+                Amount.MESSAGE_CONSTRAINTS
+        );
+    }
+
+    @Test
+    public void parse_allFieldsSpecified_success() {
+        EditCommand.EditTransactionDescriptor descriptor = new EditCommand.EditTransactionDescriptor();
+        descriptor.setPerson(TypicalPersons.ALICE);
+        descriptor.setAmount(new Amount("100"));
+        descriptor.setDescription(new Description("hello"));
+        descriptor.setDate(new Date("01012024"));
+        descriptor.setCategories(new HashSet<>(Arrays.asList(new Category("TEST"))));
+        EditCommand expectedCommand = new EditCommand(Index.fromOneBased(1), descriptor);
+
+        CommandParserTestUtil.assertParseSuccess(
+                parser, String.format(
+                        "1 p/%s amt/100 desc/hello date/01012024 cat/TEST",
+                        TypicalPersons.ALICE.getPhone().toString()
+                ),
+                expectedCommand
+        );
+    }
+
+    @Test
+    public void parse_someFieldsSpecified_success() {
+        EditCommand.EditTransactionDescriptor descriptor = new EditCommand.EditTransactionDescriptor();
+        descriptor.setPerson(TypicalPersons.ALICE);
+        descriptor.setDescription(new Description("hello"));
+        EditCommand expectedCommand = new EditCommand(Index.fromOneBased(1), descriptor);
+
+        CommandParserTestUtil.assertParseSuccess(
+                parser, String.format(
+                        "1 p/%s desc/hello",
+                        TypicalPersons.ALICE.getPhone().toString()
+                ),
+                expectedCommand
+        );
+    }
+
+    @Test
+    public void parse_multipleRepeatedFields_failure() {
+        assertThrows(ParseException.class, () -> parser.parse("1 amt/10 amt/10"));
+    }
+
+    @Test
+    public void parse_multipleRepeatedFieldsCat_success() {
+        EditCommand.EditTransactionDescriptor descriptor = new EditCommand.EditTransactionDescriptor();
+        descriptor.setCategories(new HashSet<>(Arrays.asList(new Category("TEST"), new Category("TEST2"))));
+        EditCommand expectedCommand = new EditCommand(Index.fromOneBased(1), descriptor);
+
+        CommandParserTestUtil.assertParseSuccess(parser, "1 cat/TEST cat/TEST2", expectedCommand);
+    }
+
+    @Test
+    public void parse_emptyFieldCat_clearsCats() {
+        EditCommand.EditTransactionDescriptor descriptor = new EditCommand.EditTransactionDescriptor();
+        descriptor.setCategories(new HashSet<>());
+        EditCommand expectedCommand = new EditCommand(Index.fromOneBased(1), descriptor);
+
+        CommandParserTestUtil.assertParseSuccess(parser, "1 cat/", expectedCommand);
+    }
+
+
+}

--- a/src/test/java/spleetwaise/transaction/logic/parser/FilterCommandParserTest.java
+++ b/src/test/java/spleetwaise/transaction/logic/parser/FilterCommandParserTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.Test;
 import spleetwaise.address.model.AddressBookModel;
 import spleetwaise.address.model.AddressBookModelManager;
 import spleetwaise.address.model.person.Person;
-import spleetwaise.address.model.person.Phone;
 import spleetwaise.address.testutil.TypicalPersons;
 import spleetwaise.commons.model.CommonModel;
 import spleetwaise.transaction.logic.commands.FilterCommand;
@@ -72,7 +71,7 @@ public class FilterCommandParserTest {
     @Test
     public void parse_invalidPersonField_failure() {
         String userInput = " p/9435125";
-        assertParseFailure(parser, userInput, Phone.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, userInput, ParserUtil.MESSAGE_UNKOWN_PHONE_NUMBER);
     }
 
     @Test

--- a/src/test/java/spleetwaise/transaction/logic/parser/FilterCommandParserTest.java
+++ b/src/test/java/spleetwaise/transaction/logic/parser/FilterCommandParserTest.java
@@ -71,7 +71,7 @@ public class FilterCommandParserTest {
     @Test
     public void parse_invalidPersonField_failure() {
         String userInput = " p/9435125";
-        assertParseFailure(parser, userInput, ParserUtil.MESSAGE_UNKOWN_PHONE_NUMBER);
+        assertParseFailure(parser, userInput, ParserUtil.MESSAGE_PHONE_NUMBER_IS_UNKNOWN);
     }
 
     @Test

--- a/src/test/java/spleetwaise/transaction/logic/parser/TransactionParserTest.java
+++ b/src/test/java/spleetwaise/transaction/logic/parser/TransactionParserTest.java
@@ -1,23 +1,41 @@
 package spleetwaise.transaction.logic.parser;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import spleetwaise.address.model.AddressBookModel;
 import spleetwaise.address.model.AddressBookModelManager;
+import spleetwaise.address.model.UserPrefs;
 import spleetwaise.address.testutil.TypicalPersons;
 import spleetwaise.commons.logic.commands.Command;
 import spleetwaise.commons.logic.parser.exceptions.ParseException;
 import spleetwaise.commons.model.CommonModel;
 import spleetwaise.transaction.logic.commands.AddCommand;
 import spleetwaise.transaction.logic.commands.ClearCommand;
+import spleetwaise.transaction.logic.commands.EditCommand;
+import spleetwaise.transaction.model.TransactionBookModel;
+import spleetwaise.transaction.model.TransactionBookModelManager;
 import spleetwaise.transaction.testutil.TransactionUtil;
+import spleetwaise.transaction.testutil.TypicalTransactions;
 
 
 public class TransactionParserTest {
 
+    private final TransactionBookModel tbModel = new TransactionBookModelManager(
+            TypicalTransactions.getTypicalTransactionBook());
+    private final AddressBookModel abModel = new AddressBookModelManager(
+            TypicalPersons.getTypicalAddressBook(), new UserPrefs());
     private final TransactionParser parser = new TransactionParser();
+
+
+    @BeforeEach
+    void setUp() {
+        CommonModel.initialise(abModel, tbModel);
+    }
 
     @Test
     public void parseCommand_add() throws Exception {
@@ -25,7 +43,7 @@ public class TransactionParserTest {
         aBModel.addPerson(TypicalPersons.ALICE);
         CommonModel.initialise(aBModel, null);
         AddCommand command = (AddCommand) parser.parseCommand(TransactionUtil.getAddCommand());
-        assert command != null;
+        assertNotNull(command);
     }
 
     @Test
@@ -48,5 +66,12 @@ public class TransactionParserTest {
     @Test
     public void parseCommand_unknownCommand_returnsNull() throws ParseException {
         assertNull(parser.parseCommand("unknownCommand"));
+    }
+
+    @Test
+    public void parseCommand_editTxnCommand() throws ParseException {
+        EditCommand command = (EditCommand) parser.parseCommand(
+                String.format("editTxn 1 p/%s", TypicalPersons.ALICE.getPhone()));
+        assertNotNull(command);
     }
 }

--- a/src/test/java/spleetwaise/transaction/model/TransactionBookTest.java
+++ b/src/test/java/spleetwaise/transaction/model/TransactionBookTest.java
@@ -22,7 +22,9 @@ import spleetwaise.transaction.model.transaction.Date;
 import spleetwaise.transaction.model.transaction.Description;
 import spleetwaise.transaction.model.transaction.Transaction;
 import spleetwaise.transaction.model.transaction.exceptions.DuplicateTransactionException;
+import spleetwaise.transaction.model.transaction.exceptions.TransactionNotFoundException;
 import spleetwaise.transaction.testutil.TransactionBuilder;
+import spleetwaise.transaction.testutil.TypicalTransactions;
 
 public class TransactionBookTest {
 
@@ -127,14 +129,14 @@ public class TransactionBookTest {
     }
 
     @Test
-    public void setTransaction_null_exceptionThrown() {
+    public void setTransactionBook_null_exceptionThrown() {
         TransactionBook book = new TransactionBook();
 
         assertThrows(NullPointerException.class, () -> book.setTransactionBook(null));
     }
 
     @Test
-    public void setTransaction_validParams_success() {
+    public void setTransactionBook_validParams_success() {
         TransactionBook book = new TransactionBook();
         book.addTransaction(testTxn);
 
@@ -147,6 +149,28 @@ public class TransactionBookTest {
         assertFalse(book.containsTransaction(testTxn));
         assertTrue(book.containsTransaction(testTxn2));
         assertTrue(book.containsTransaction(testTxn3));
+    }
+
+    @Test
+    public void setTransaction_null_throws() {
+        TransactionBook book = TypicalTransactions.getTypicalTransactionBook();
+        Transaction someTransaction = book.getTransactionList().get(0);
+
+        assertThrows(NullPointerException.class, () -> book.setTransaction(null, null));
+        assertThrows(NullPointerException.class, () -> book.setTransaction(someTransaction, null));
+        assertThrows(NullPointerException.class, () -> book.setTransaction(null, someTransaction));
+        assertThrows(TransactionNotFoundException.class, () -> book.setTransaction(testTxn, testTxn2));
+    }
+
+    @Test
+    public void setTransaction_validParams_success() {
+        TransactionBook book = TypicalTransactions.getTypicalTransactionBook();
+        Transaction someTransaction = book.getTransactionList().get(0);
+
+        book.setTransaction(someTransaction, testTxn);
+
+        assertEquals(book.getTransactionList().get(0), testTxn);
+
     }
 
     @Test

--- a/src/test/java/spleetwaise/transaction/model/TransactionBookTest.java
+++ b/src/test/java/spleetwaise/transaction/model/TransactionBookTest.java
@@ -130,7 +130,7 @@ public class TransactionBookTest {
     public void setTransaction_null_exceptionThrown() {
         TransactionBook book = new TransactionBook();
 
-        assertThrows(NullPointerException.class, () -> book.setTransactions(null));
+        assertThrows(NullPointerException.class, () -> book.setTransactionBook(null));
     }
 
     @Test
@@ -142,7 +142,7 @@ public class TransactionBookTest {
         replacementBook.addTransaction(testTxn2);
         replacementBook.addTransaction(testTxn3);
 
-        book.setTransactions(replacementBook);
+        book.setTransactionBook(replacementBook);
 
         assertFalse(book.containsTransaction(testTxn));
         assertTrue(book.containsTransaction(testTxn2));


### PR DESCRIPTION
Closes #190 

## Added `EditTxn` Command:

- Introduced a new `EditCommand` class to handle editing transactions in the transaction book.
- Implemented `EditCommandParser` to parse input arguments for the editTxn command.
- Updated `TransactionParser` to recognize and parse the editTxn command.

## `AddressBook` Enhancements:
- Added a method `getPersonByPhone` in `AddressBook` to retrieve a person using their phone number.
- Updated `AddressBookModel`, `AddressBookModelManager`, and `CommonModel` to support searching for a person by phone.

## `TransactionBook` Enhancements:

- Added `setTransaction` method in `TransactionBook` to replace a transaction with a new one.
- Introduced `TransactionNotFoundException` for handling cases where a transaction to be edited is not found.

## Testing:

- Added tests for `EditCommand` and `EditCommandParser`.
- Updated existing tests to accommodate changes in method signatures and new functionality.
- Documentation:

## User Guide:

- Updated the User Guide to include instructions and examples for the new editTxn command.
- Modified command summary to reflect the addition of the editTxn command.