### PR TITLE
Fix data loss issue

### DIFF
--- a/src/test/java/spleetwaise/transaction/storage/JsonSerializableTransactionBookTest.java
+++ b/src/test/java/spleetwaise/transaction/storage/JsonSerializableTransactionBookTest.java
@@ -8,12 +8,10 @@ import java.nio.file.Paths;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import spleetwaise.address.commons.exceptions.IllegalValueException;
 import spleetwaise.address.commons.util.JsonUtil;
 import spleetwaise.address.model.AddressBookModel;
 import spleetwaise.address.model.AddressBookModelManager;
 import spleetwaise.address.model.person.Person;
-import spleetwaise.address.testutil.Assert;
 import spleetwaise.address.testutil.TypicalPersons;
 import spleetwaise.transaction.model.TransactionBook;
 import spleetwaise.transaction.testutil.TypicalTransactions;
@@ -39,7 +37,7 @@ public class JsonSerializableTransactionBookTest {
     }
 
     @Test
-    public void toModelType_typicalPersonsFile_success() throws Exception {
+    public void toModelType_typicalTransactionFile_success() throws Exception {
         JsonSerializableTransactionBook dataFromFile = JsonUtil.readJsonFile(
                 TYPICAL_TXN_FILE,
                 JsonSerializableTransactionBook.class
@@ -50,24 +48,24 @@ public class JsonSerializableTransactionBookTest {
     }
 
     @Test
-    public void toModelType_invalidPersonFile_throwsIllegalValueException() throws Exception {
+    public void toModelType_invalidTransactionFile_throwsIllegalValueException() throws Exception {
         JsonSerializableTransactionBook dataFromFile = JsonUtil.readJsonFile(
                 INVALID_TXN_FILE,
                 JsonSerializableTransactionBook.class
         ).get();
-        Assert.assertThrows(IllegalValueException.class, () -> dataFromFile.toModelType(addressBookModel));
+        TransactionBook tb = dataFromFile.toModelType(addressBookModel);
+        assertEquals(1, tb.getTransactionList().size());
     }
 
     @Test
-    public void toModelType_duplicatePersons_throwsIllegalValueException() throws Exception {
+    public void toModelType_duplicateTransactions_throwsIllegalValueException() throws Exception {
         JsonSerializableTransactionBook dataFromFile = JsonUtil.readJsonFile(
                 DUPLICATE_TXN_FILE,
                 JsonSerializableTransactionBook.class
         ).get();
-        Assert.assertThrows(IllegalValueException.class,
-                JsonSerializableTransactionBook.MESSAGE_DUPLICATE_TRANSACTIONS, (
-                ) -> dataFromFile.toModelType(addressBookModel)
-        );
+
+        TransactionBook tb = dataFromFile.toModelType(addressBookModel);
+        assertEquals(1, tb.getTransactionList().size());
     }
 
     @Test
@@ -76,10 +74,8 @@ public class JsonSerializableTransactionBookTest {
                 DUPLICATE_ID_TXN_FILE,
                 JsonSerializableTransactionBook.class
         ).get();
-        Assert.assertThrows(
-                IllegalValueException.class,
-                JsonSerializableTransactionBook.MESSAGE_DUPLICATE_TRANSACTIONS, (
-                ) -> dataFromFile.toModelType(addressBookModel)
-        );
+
+        TransactionBook tb = dataFromFile.toModelType(addressBookModel);
+        assertEquals(1, tb.getTransactionList().size());
     }
 }

--- a/src/test/java/spleetwaise/transaction/storage/JsonTransactionBookStorageTest.java
+++ b/src/test/java/spleetwaise/transaction/storage/JsonTransactionBookStorageTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -65,21 +66,17 @@ public class JsonTransactionBookStorageTest {
     }
 
     @Test
-    public void readTxnBook_invalidPerson_throwDataLoadingException() {
-        Assert.assertThrows(DataLoadingException.class,
-                "spleetwaise.address.commons.exceptions.IllegalValueException: Person with id "
-                        + "420yoloswag not found!", () -> readTxnBook("invalidPersonTransactionBook" + ".json")
-        );
+    public void readTxnBook_invalidPerson_throwDataLoadingException() throws Exception {
+        Optional<ReadOnlyTransactionBook> optionalTb = readTxnBook("invalidPersonTransactionBook" + ".json");
+        assert optionalTb.isPresent();
+        assertEquals(0, optionalTb.get().getTransactionList().size());
     }
 
     @Test
-    public void readTxnBook_missingAmount_throwDataLoadingException() {
-        Assert.assertThrows(
-                DataLoadingException.class,
-                "spleetwaise.address.commons.exceptions.IllegalValueException:"
-                        + " Transaction's Amount field is missing!", (
-                ) -> readTxnBook("missingAmountTransactionBook" + ".json")
-        );
+    public void readTxnBook_missingAmount_throwDataLoadingException() throws Exception {
+        Optional<ReadOnlyTransactionBook> optionalTb = readTxnBook("missingAmountTransactionBook" + ".json");
+        assert optionalTb.isPresent();
+        assertEquals(0, optionalTb.get().getTransactionList().size());
     }
 
     @Test


### PR DESCRIPTION
Closes #226 

When invalid transactions are encountered, the program drops them with a warning in the logs that the transaction book might be corrupted.

A valid transaction book can then be saved over the corrupted one with minimal data loss.