### PR TITLE
Add shutDownHook to execute stop()

### DIFF
--- a/src/main/java/spleetwaise/address/MainApp.java
+++ b/src/main/java/spleetwaise/address/MainApp.java
@@ -86,6 +86,15 @@ public class MainApp extends Application {
         logic = new LogicManager(storage);
 
         ui = new UiManager(logic);
+
+        // Add shutdown hook
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            try {
+                stop();
+            } catch (Exception e) {
+                logger.severe("Error during shutdown: " + e.getMessage());
+            }
+        }));
     }
 
     /**


### PR DESCRIPTION
Fixes #232 

This PR adds a `Runtime.getRuntime().addShutdownHook` method which is supposedly platform-independent and should ensure that the `stop()` method is called when the application is terminated, regardless of the operating system. This includes handling scenarios where the application is forced to quit.

Need Windows Users to test this out.