### PR TITLE
Change FilterCommandParser to accept index instead of phone number

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -187,14 +187,15 @@ Examples:
 
 ### Filtering transactions: `filterTxn`
 
-Filter transactions with the specified person identified by their phone number, and/or amount and/or description
-and/or date.
+Filter transactions with the specified person identified by their index in the displayed person list, and/or amount 
+and/or description and/or date.
 
-Format: `filterTxn [p/PHONE_NUMBER] [amt/AMOUNT] [desc/DESCRIPTION] [date/DATE]`
+Format: `filterTxn [INDEX] [amt/AMOUNT] [desc/DESCRIPTION] [date/DATE]`
 
 * The command requires at least one of the above optional prefixes to be provided.
 * As more prefixes are provided, the filter becomes more specific.
-* The `PHONE_NUMBER` refers to the phone number associated to the person had a transaction with.
+* The `INDEX` refers to the index number shown in the displayed person list.
+  The index **must be a positive integer** 1, 2, 3, …​
 * The `AMOUNT` accepts a decimal number with up to 2 decimal places. A `-` can be added as prefix to indicate negative
   amount.
 * The `DATE` accepts date formatted in the form `DDMMYYYY` i.e.`10102024`.
@@ -205,10 +206,12 @@ Examples:<br>
 
 * Given the example transaction book:<br>
   ![Given the example transaction book](images/filterTxnExample.png)
-* `filterTxn p/87438807` returns all transactions with the person `Alex Yeoh`.<br>
-  ![result fpr 'filterTxn p/87438807'](images/filterTxnAlexYeohResult.png)
-* `filterTxn p/99272758 amt/5.5` returns all transactions with the person `Bernice Yu` with amount `5.50`.<br>
-  ![result for 'filterTxn p/99272758 amt/5.5'](images/filterTxnBerniceYuAmt55Result.png)
+* `filterTxn 1` returns all transactions with the person `Alex Yeoh`. Given that `1` is the index of `Alex Yeoh` in 
+  the displayed person list.<br>
+  ![result fpr 'filterTxn 1'](images/filterTxnAlexYeohResult.png)
+* `filterTxn 2 amt/5.5` returns all transactions with the person `Bernice Yu` with amount `5.50`. Givent that `2` is 
+  the index of `Bernice Yu` in the displayed person list.<br>
+  ![result for 'filterTxn 2 amt/5.5'](images/filterTxnBerniceYuAmt55Result.png)
 
 ### Adding Remarks for a person : `remark`
 
@@ -382,5 +385,5 @@ _Details coming soon ..._
 | **Add**    | `addTxn INDEX amt/AMOUNT desc/DESCRIPTION [date/DATE] [cat/CATEGORY]` <br> e.g., `addTxn 1 amt/9999999999.99 desc/Sean owes me a lot for a plot of land in sentosa date/10102024 cat/LOAN`                                   |
 | **Edit**   | `editTxn INDEX [p/PHONE_NUMBER] [amt/AMOUNT] [desc/DESCRIPTION] [date/DATE] [cat/CATEGORY]` <br> e.g., `editTxn 1 p/99999999 amt/9999999999.99 desc/Sean owes me a lot for a plot of land in sentosa date/10102024 cat/LOAN` |
 | **List**   | `listTxn`                                                                                                                                                                                                                    |
-| **Filter** | `filterTxn [p/PHONE_NUMBER] [amt/AMOUNT] [desc/DESCRIPTION] [date/DATE]` <br> e.g. `filterTxn p/99999999`                                                                                                                    |
+| **Filter** | `filterTxn [INDEX] [amt/AMOUNT] [desc/DESCRIPTION] [date/DATE]` <br> e.g. `filterTxn 1`                                                                                                                                      |
 | **Clear**  | `clearTxn`                                                                                                                                                                                                                   |

--- a/src/main/java/spleetwaise/address/model/AddressBook.java
+++ b/src/main/java/spleetwaise/address/model/AddressBook.java
@@ -7,12 +7,10 @@ import java.util.Optional;
 
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
-import spleetwaise.address.commons.core.index.Index;
 import spleetwaise.address.commons.util.ToStringBuilder;
 import spleetwaise.address.model.person.Person;
 import spleetwaise.address.model.person.Phone;
 import spleetwaise.address.model.person.UniquePersonList;
-import spleetwaise.commons.model.CommonModel;
 
 /**
  * Wraps all data at the address-book level Duplicates are not allowed (by .isSamePerson comparison)

--- a/src/main/java/spleetwaise/address/model/AddressBook.java
+++ b/src/main/java/spleetwaise/address/model/AddressBook.java
@@ -63,11 +63,17 @@ public class AddressBook implements ReadOnlyAddressBook {
 
     //// person-level operations
 
+    /**
+     * Searches for a person by id and returns an optional Person
+     */
     public Optional<Person> getPersonById(String id) {
         requireNonNull(id);
         return persons.getPersonById(id);
     }
 
+    /**
+     * Searches for a person by phone and returns an optional Person
+     */
     public Optional<Person> getPersonByPhone(Phone phone) {
         requireNonNull(phone);
 
@@ -76,17 +82,6 @@ public class AddressBook implements ReadOnlyAddressBook {
             return Optional.empty();
         }
         return Optional.of(filteredPersonList.get(0));
-    }
-
-    public Optional<Person> getPersonByFilteredPersonListIndex(Index index) {
-        requireNonNull(index);
-
-        List<Person> lastShownList = CommonModel.getInstance().getFilteredPersonList();
-
-        if (lastShownList.isEmpty()) {
-            return Optional.empty();
-        }
-        return Optional.of(lastShownList.get(index.getZeroBased()));
     }
 
     /**

--- a/src/main/java/spleetwaise/address/model/AddressBookModelManager.java
+++ b/src/main/java/spleetwaise/address/model/AddressBookModelManager.java
@@ -149,7 +149,12 @@ public class AddressBookModelManager implements AddressBookModel {
     @Override
     public Optional<Person> getPersonByFilteredPersonListIndex(Index index) {
         requireNonNull(index);
-        return addressBook.getPersonByFilteredPersonListIndex(index);
+
+        if (index.getZeroBased() >= filteredPersons.size()) {
+            return Optional.empty();
+        }
+
+        return Optional.of(filteredPersons.get(index.getZeroBased()));
     }
 
     @Override

--- a/src/main/java/spleetwaise/transaction/logic/parser/FilterCommandParser.java
+++ b/src/main/java/spleetwaise/transaction/logic/parser/FilterCommandParser.java
@@ -1,7 +1,6 @@
 package spleetwaise.transaction.logic.parser;
 
 import static spleetwaise.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static spleetwaise.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static spleetwaise.transaction.logic.commands.FilterCommand.MESSAGE_USAGE;
 import static spleetwaise.transaction.logic.parser.CliSyntax.PREFIX_AMOUNT;
 import static spleetwaise.transaction.logic.parser.CliSyntax.PREFIX_DATE;
@@ -9,11 +8,11 @@ import static spleetwaise.transaction.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 
 import java.util.stream.Stream;
 
+import spleetwaise.address.commons.core.index.Index;
 import spleetwaise.address.logic.parser.ArgumentMultimap;
 import spleetwaise.address.logic.parser.ArgumentTokenizer;
 import spleetwaise.address.logic.parser.Prefix;
 import spleetwaise.address.model.person.Person;
-import spleetwaise.address.model.person.Phone;
 import spleetwaise.commons.logic.parser.Parser;
 import spleetwaise.commons.logic.parser.exceptions.ParseException;
 import spleetwaise.transaction.logic.commands.FilterCommand;
@@ -44,18 +43,17 @@ public class FilterCommandParser implements Parser<FilterCommand> {
      */
     public FilterCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_PHONE, PREFIX_AMOUNT, PREFIX_DESCRIPTION, PREFIX_DATE);
-        if (!areAnyPrefixesPresent(argMultimap, PREFIX_PHONE, PREFIX_AMOUNT, PREFIX_DESCRIPTION, PREFIX_DATE)
-                || !argMultimap.getPreamble().isEmpty()) {
+                ArgumentTokenizer.tokenize(args, PREFIX_AMOUNT, PREFIX_DESCRIPTION, PREFIX_DATE);
+        if (!areAnyPrefixesPresent(argMultimap, PREFIX_AMOUNT, PREFIX_DESCRIPTION, PREFIX_DATE)
+                && argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
         }
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_PHONE, PREFIX_AMOUNT, PREFIX_DESCRIPTION, PREFIX_DATE);
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_AMOUNT, PREFIX_DESCRIPTION, PREFIX_DATE);
 
         Person person = null;
-        if (argMultimap.getValue(PREFIX_PHONE).isPresent()) {
-            Phone phone = spleetwaise.address.logic.parser.ParserUtil.parsePhone(
-                    argMultimap.getValue(PREFIX_PHONE).get());
-            person = ParserUtil.getPersonFromPhone(phone);
+        if (!argMultimap.getPreamble().isEmpty()) {
+            Index index = ParserUtil.parseIndex(argMultimap.getPreamble());
+            person = ParserUtil.getPersonFromAddressBookIndex(index);
         }
 
         Amount amount = null;

--- a/src/main/java/spleetwaise/transaction/logic/parser/ParserUtil.java
+++ b/src/main/java/spleetwaise/transaction/logic/parser/ParserUtil.java
@@ -125,6 +125,13 @@ public class ParserUtil {
         return p.get();
     }
 
+    /**
+     * Finds the corresponding Person displayed on the current Address Book view with the provided index.
+     *
+     * @param index The 1-based index corresponding to the Person entry.
+     * @return A Person who has the specified index in the current Address Book view.
+     * @throws ParseException Invalid index or index is out of bounds.
+     */
     public static Person getPersonFromAddressBookIndex(Index index) throws ParseException {
         requireNonNull(index);
         Optional<Person> p = CommonModel.getInstance().getPersonByFilteredPersonListIndex(index);

--- a/src/test/java/spleetwaise/transaction/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/spleetwaise/transaction/logic/parser/AddCommandParserTest.java
@@ -1,6 +1,7 @@
 package spleetwaise.transaction.logic.parser;
 
 import static spleetwaise.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static spleetwaise.address.logic.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
 import static spleetwaise.transaction.logic.parser.CliSyntax.PREFIX_CATEGORY;
 import static spleetwaise.transaction.logic.parser.CliSyntax.PREFIX_DATE;
 import static spleetwaise.transaction.logic.parser.CommandParserTestUtil.assertParseFailure;
@@ -11,9 +12,10 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import spleetwaise.address.model.AddressBookModel;
 import spleetwaise.address.model.AddressBookModelManager;
 import spleetwaise.address.model.person.Person;
 import spleetwaise.address.testutil.TypicalPersons;
@@ -36,13 +38,14 @@ public class AddCommandParserTest {
     private static final Description testDescription = new Description("description");
     private static final Date testDate = new Date(getNowDate());
     private static final Set<Category> testCategories = new HashSet<>(List.of(new Category("FOOD")));
+    private static final AddressBookModel abModel = new AddressBookModelManager();
 
     private final AddCommandParser parser = new AddCommandParser();
 
-    @BeforeEach
-    void setup() {
-        CommonModel.initialise(new AddressBookModelManager(), null);
-        CommonModel.getInstance().addPerson(testPerson);
+    @BeforeAll
+    public static void setUp() {
+        abModel.addPerson(testPerson);
+        CommonModel.initialise(abModel, null);
     }
 
     @Test
@@ -63,11 +66,17 @@ public class AddCommandParserTest {
 
     @Test
     public void parse_invalidIndex_exceptionThrown() {
-        String userInput1 = " 0 amt/1.23 desc/description date/01012024";
-        assertParseFailure(parser, userInput1, MESSAGE_INVALID_FORMAT);
+        String userInput = " 0 amt/1.23 desc/description date/01012024";
+        assertParseFailure(parser, userInput, MESSAGE_INVALID_FORMAT);
 
-        String userInput2 = " -1 amt/1.23 desc/description date/01012024";
-        assertParseFailure(parser, userInput2, MESSAGE_INVALID_FORMAT);
+        userInput = " -1 amt/1.23 desc/description date/01012024";
+        assertParseFailure(parser, userInput, MESSAGE_INVALID_FORMAT);
+
+        userInput = " invalid amt/1.23 desc/description date/01012024";
+        assertParseFailure(parser, userInput, MESSAGE_INVALID_FORMAT);
+
+        userInput = " " + (abModel.getFilteredPersonList().size() + 1) + " amt/1.23 desc/description date/01012024";
+        assertParseFailure(parser, userInput, MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
 
     @Test

--- a/src/test/java/spleetwaise/transaction/logic/parser/FilterCommandParserTest.java
+++ b/src/test/java/spleetwaise/transaction/logic/parser/FilterCommandParserTest.java
@@ -6,6 +6,7 @@ import static spleetwaise.transaction.logic.parser.CommandParserTestUtil.assertP
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import spleetwaise.address.logic.Messages;
 import spleetwaise.address.model.AddressBookModel;
 import spleetwaise.address.model.AddressBookModelManager;
 import spleetwaise.address.model.person.Person;
@@ -40,7 +41,7 @@ public class FilterCommandParserTest {
 
     @Test
     public void parse_personField_success() {
-        String userInput = " p/94351253";
+        String userInput = " 1";
         FilterCommandPredicate expectedPred = new FilterCommandPredicate(testPerson, null, null, null);
 
         assertParseSuccess(parser, userInput, new FilterCommand(expectedPred));
@@ -72,7 +73,7 @@ public class FilterCommandParserTest {
 
     @Test
     public void parse_allFields_success() {
-        String userInput = " p/94351253 amt/9999999999.99  "
+        String userInput = " 1 amt/9999999999.99  "
                 + "desc/Sean owes me a lot for a landed property in Sentosa date/10102024";
         FilterCommandPredicate expectedPred = new FilterCommandPredicate(testPerson, testAmount,
                 testDescription, testDate);
@@ -81,9 +82,15 @@ public class FilterCommandParserTest {
     }
 
     @Test
-    public void parse_invalidPersonField_failure() {
-        String userInput = " p/9435125";
-        assertParseFailure(parser, userInput, ParserUtil.MESSAGE_PHONE_NUMBER_IS_UNKNOWN);
+    public void parse_invalidIndexField_failure() {
+        String userInput = " 0";
+        assertParseFailure(parser, userInput, ParserUtil.MESSAGE_INVALID_INDEX);
+
+        userInput = " invalid";
+        assertParseFailure(parser, userInput, ParserUtil.MESSAGE_INVALID_INDEX);
+
+        userInput = " " + abModel.getFilteredPersonList().size() + 1;
+        assertParseFailure(parser, userInput, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
 
     @Test

--- a/src/test/java/spleetwaise/transaction/logic/parser/FilterCommandParserTest.java
+++ b/src/test/java/spleetwaise/transaction/logic/parser/FilterCommandParserTest.java
@@ -1,5 +1,7 @@
 package spleetwaise.transaction.logic.parser;
 
+import static spleetwaise.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static spleetwaise.transaction.logic.commands.FilterCommand.MESSAGE_USAGE;
 import static spleetwaise.transaction.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static spleetwaise.transaction.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
@@ -79,6 +81,12 @@ public class FilterCommandParserTest {
                 testDescription, testDate);
 
         assertParseSuccess(parser, userInput, new FilterCommand(expectedPred));
+    }
+
+    @Test
+    public void parse_noField_failure() {
+        String userInput = " ";
+        assertParseFailure(parser, userInput, String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
     }
 
     @Test


### PR DESCRIPTION
Currently, FilterCommandParser takes in a phone number to find the corresponding person. This PR changes the implementation to take in an index based on the currently displayed person list and use that index to find the corresponding person instead.

Resolves #212. 