### PR TITLE
Add deleteTxn UG

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -244,6 +244,21 @@ Examples:
 * `list` followed by `delete 2` deletes the 2nd person in the address book.
 * `find Betsy` followed by `delete 1` deletes the 1st person in the results of the `find` command.
 
+### Deleting a transaction : `deleteTxn`
+
+Deletes the specified transaction from the transaction book.
+
+Format: `deleteTxn INDEX`
+
+* Deletes the transaction at the specified `INDEX`.
+* The index refers to the index number shown in the displayed transaction list.
+* The index **must be a positive integer** 1, 2, 3, …​
+
+Examples:
+
+* `listTxn` followed by `delete 2` deletes the 2nd person in the address book.
+* `filterTxn 1` followed by `delete 1` deletes the 1st transaction in the results of the `filterTxn` command.
+
 ### Clearing all entries of AddressBook: `clear`
 
 Clears all entries from the address book.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -150,7 +150,7 @@ Format: `listTxn`
 
 Edits an existing person in the address book.
 
-Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [t/TAG]…​`
+Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [r/REMARK] [t/TAG]…​`
 
 * Edits the person at the specified `INDEX`. The index refers to the index number shown in the displayed person list.
   The index **must be a positive integer** 1, 2, 3, …​
@@ -164,6 +164,7 @@ Examples:
 
 * `edit 1 p/91234567 e/johndoe@example.com` Edits the phone number and email address of the 1st person to be `91234567`
   and `johndoe@example.com` respectively.
+* `edit 2 r/` Edits the 2nd person by deleting the remark.
 * `edit 2 n/Betsy Crower t/` Edits the name of the 2nd person to be `Betsy Crower` and clears all existing tags.
 
 ### Editing a transaction : `editTxn `
@@ -235,21 +236,23 @@ Examples:<br>
   the index of `Bernice Yu` in the displayed person list.<br>
   ![result for 'filterTxn 2 amt/5.5'](images/filterTxnBerniceYuAmt55Result.png)
 
-### Adding Remarks for a person : `remark`
+### Adding/Deleting Remarks for a person : `remark`
 
-Add remarks for the specified person from the address book.
+Add/Delete remarks for the specified person from the address book.
 
 Format: `remark INDEX r/REMARK`
 
-* Add remarks for the person at the specified `INDEX`.
+* Add/delete remarks for the person at the specified `INDEX`.
 * The index refers to the index number shown in the displayed person list.
 * The index **must be a positive integer** 1, 2, 3, …​
 
 Examples:
 
 * `list` followed by `remark 2 r/remark for person 2` adds remarks for the 2nd person in the address book.
+* `list` followed by `remark 1 r/` deletes the remarks for the 1st person in the address book.
 * `find Betsy` followed by `remark 1 r/remark for betsy` adds remarks for the 1st person in the results of the `find`
   command.
+* `find Betsy` followed by `remark 1 r/` deletes the remarks for the 1st person in the results of the `find` command.
 
 ### Deleting a person : `delete`
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -166,6 +166,28 @@ Examples:
   and `johndoe@example.com` respectively.
 * `edit 2 n/Betsy Crower t/` Edits the name of the 2nd person to be `Betsy Crower` and clears all existing tags.
 
+### Editing a transaction : `editTxn `
+
+Edits an existing transaction in the transaction book.
+
+Format: `editTxn INDEX [p/PHONE_NUMBER] [amt/AMOUNT] [desc/TEST] [date/DATE] [cat/CATEGORY]...`
+
+* Edits the transaction at the specified `INDEX`. The index refers to the index number shown in the displayed person
+  list.
+  The index **must be a positive integer** 1, 2, 3, …
+* At least one of the optional fields must be provided.
+* Existing values will be updated to the input values.
+* When editing categories, the existing categories of the person will be removed i.e adding of categories is not
+  cumulative.
+* You can remove all the person’s categories by typing `cat/` without
+  specifying any categories after it.
+
+Examples:
+
+* `editTxn 1 p/91234567 desc/Hello world` Edits the phone number and description of the 1st transaction to be `91234567`
+  and `Hello world` respectively.
+* `editTxn 2 cat/` Edits the 2nd transaction by removing all existing categories.
+
 ### Locating persons by name: `find`
 
 Finds persons whose names contain any of the given keywords.
@@ -270,28 +292,6 @@ Format: `clear`
 Clears all entries from the transaction book.
 
 Format: `clearTxn`
-
-### Editing a transaction : `editTxn `
-
-Edits an existing transaction in the transaction book.
-
-Format: `editTxn INDEX [p/PHONE_NUMBER] [amt/AMOUNT] [desc/TEST] [date/DATE] [cat/CATEGORY]...`
-
-* Edits the transaction at the specified `INDEX`. The index refers to the index number shown in the displayed person
-  list.
-  The index **must be a positive integer** 1, 2, 3, …
-* At least one of the optional fields must be provided.
-* Existing values will be updated to the input values.
-* When editing categories, the existing categories of the person will be removed i.e adding of categories is not
-  cumulative.
-* You can remove all the person’s categories by typing `cat/` without
-  specifying any categories after it.
-
-Examples:
-
-* `editTxn 1 p/91234567 desc/Hello world` Edits the phone number and description of the 1st transaction to be `91234567`
-  and `Hello world` respectively.
-* `editTxn 2 cat/` Edits the 2nd transaction by removing all existing categories.
 
 ### Marking a transaction as done : `markDone`
 


### PR DESCRIPTION
Closes #243
This PR introduces changes to the User Guide documentation, specifically adding details about the `deleteTxn` command and updating the section on `edit` and `remark` commands to make it complete.