### PR TITLE
Allow `filterTxn` to filter by status

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -187,10 +187,14 @@ Examples:
 
 ### Filtering transactions: `filterTxn`
 
-Filter transactions with the specified person identified by their index in the displayed person list, and/or amount 
-and/or description and/or date.
+Filter transactions with a any combination of the following parameters:
+* the specified person identified by their index in the displayed person list
+* and/or amount 
+* and/or description 
+* and/or date
+* and/or status
 
-Format: `filterTxn [INDEX] [amt/AMOUNT] [desc/DESCRIPTION] [date/DATE]`
+Format: `filterTxn [INDEX] [amt/AMOUNT] [desc/DESCRIPTION] [date/DATE] [status/STATUS]`
 
 * The command requires at least one of the above optional prefixes to be provided.
 * As more prefixes are provided, the filter becomes more specific.
@@ -201,6 +205,7 @@ Format: `filterTxn [INDEX] [amt/AMOUNT] [desc/DESCRIPTION] [date/DATE]`
 * The `DATE` accepts date formatted in the form `DDMMYYYY` i.e.`10102024`.
 * The `DESCRIPTION` accepts a string of words.
     * The description filter is case-insensitive. e.g `hans` will match `Hans`
+* The `STATUS` accepts either `Done` or `Not Done` to indicate filtering for transactions that are done or not done.
 
 Examples:<br>
 
@@ -385,5 +390,5 @@ _Details coming soon ..._
 | **Add**    | `addTxn INDEX amt/AMOUNT desc/DESCRIPTION [date/DATE] [cat/CATEGORY]` <br> e.g., `addTxn 1 amt/9999999999.99 desc/Sean owes me a lot for a plot of land in sentosa date/10102024 cat/LOAN`                                   |
 | **Edit**   | `editTxn INDEX [p/PHONE_NUMBER] [amt/AMOUNT] [desc/DESCRIPTION] [date/DATE] [cat/CATEGORY]` <br> e.g., `editTxn 1 p/99999999 amt/9999999999.99 desc/Sean owes me a lot for a plot of land in sentosa date/10102024 cat/LOAN` |
 | **List**   | `listTxn`                                                                                                                                                                                                                    |
-| **Filter** | `filterTxn [INDEX] [amt/AMOUNT] [desc/DESCRIPTION] [date/DATE]` <br> e.g. `filterTxn 1`                                                                                                                                      |
+| **Filter** | `filterTxn [INDEX] [amt/AMOUNT] [desc/DESCRIPTION] [date/DATE] [status/STATUS]` <br> e.g. `filterTxn 1`                                                                                                                      |
 | **Clear**  | `clearTxn`                                                                                                                                                                                                                   |

--- a/src/main/java/spleetwaise/transaction/logic/parser/CliSyntax.java
+++ b/src/main/java/spleetwaise/transaction/logic/parser/CliSyntax.java
@@ -12,4 +12,5 @@ public class CliSyntax {
     public static final Prefix PREFIX_DESCRIPTION = new Prefix("desc/");
     public static final Prefix PREFIX_DATE = new Prefix("date/");
     public static final Prefix PREFIX_CATEGORY = new Prefix("cat/");
+    public static final Prefix PREFIX_STATUS = new Prefix("status/");
 }

--- a/src/main/java/spleetwaise/transaction/logic/parser/FilterCommandParser.java
+++ b/src/main/java/spleetwaise/transaction/logic/parser/FilterCommandParser.java
@@ -5,6 +5,7 @@ import static spleetwaise.transaction.logic.commands.FilterCommand.MESSAGE_USAGE
 import static spleetwaise.transaction.logic.parser.CliSyntax.PREFIX_AMOUNT;
 import static spleetwaise.transaction.logic.parser.CliSyntax.PREFIX_DATE;
 import static spleetwaise.transaction.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
+import static spleetwaise.transaction.logic.parser.CliSyntax.PREFIX_STATUS;
 
 import java.util.stream.Stream;
 
@@ -20,6 +21,7 @@ import spleetwaise.transaction.model.FilterCommandPredicate;
 import spleetwaise.transaction.model.transaction.Amount;
 import spleetwaise.transaction.model.transaction.Date;
 import spleetwaise.transaction.model.transaction.Description;
+import spleetwaise.transaction.model.transaction.Status;
 
 /**
  * Parses input arguments and creates a new transaction FilterCommand object.
@@ -43,12 +45,12 @@ public class FilterCommandParser implements Parser<FilterCommand> {
      */
     public FilterCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_AMOUNT, PREFIX_DESCRIPTION, PREFIX_DATE);
-        if (!areAnyPrefixesPresent(argMultimap, PREFIX_AMOUNT, PREFIX_DESCRIPTION, PREFIX_DATE)
+                ArgumentTokenizer.tokenize(args, PREFIX_AMOUNT, PREFIX_DESCRIPTION, PREFIX_DATE, PREFIX_STATUS);
+        if (!areAnyPrefixesPresent(argMultimap, PREFIX_AMOUNT, PREFIX_DESCRIPTION, PREFIX_DATE, PREFIX_STATUS)
                 && argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
         }
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_AMOUNT, PREFIX_DESCRIPTION, PREFIX_DATE);
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_AMOUNT, PREFIX_DESCRIPTION, PREFIX_DATE, PREFIX_STATUS);
 
         Person person = null;
         if (!argMultimap.getPreamble().isEmpty()) {
@@ -71,9 +73,14 @@ public class FilterCommandParser implements Parser<FilterCommand> {
             date = ParserUtil.parseDate(argMultimap.getValue(PREFIX_DATE).get());
         }
 
-        assert person != null || amount != null || description != null || date != null;
+        Status status = null;
+        if (argMultimap.getValue(PREFIX_STATUS).isPresent()) {
+            status = ParserUtil.parseStatus(argMultimap.getValue(PREFIX_STATUS).get());
+        }
 
-        FilterCommandPredicate filterPredicate = new FilterCommandPredicate(person, amount, description, date);
+        assert person != null || amount != null || description != null || date != null || status != null;
+
+        FilterCommandPredicate filterPredicate = new FilterCommandPredicate(person, amount, description, date, status);
 
         return new FilterCommand(filterPredicate);
     }

--- a/src/main/java/spleetwaise/transaction/logic/parser/ParserUtil.java
+++ b/src/main/java/spleetwaise/transaction/logic/parser/ParserUtil.java
@@ -18,6 +18,7 @@ import spleetwaise.transaction.model.transaction.Amount;
 import spleetwaise.transaction.model.transaction.Category;
 import spleetwaise.transaction.model.transaction.Date;
 import spleetwaise.transaction.model.transaction.Description;
+import spleetwaise.transaction.model.transaction.Status;
 
 /**
  * Contains utility methods used for parsing strings in the various *Parser classes.
@@ -82,6 +83,20 @@ public class ParserUtil {
             throw new ParseException(Date.MESSAGE_CONSTRAINTS);
         }
         return new Date(date);
+    }
+
+    /**
+     * Parses a {@code String status} into a {@code Status}. Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code status} is invalid.
+     */
+    public static Status parseStatus(String status) throws ParseException {
+        requireNonNull(status);
+        status = status.trim();
+        if (!Status.isValidStatus(status)) {
+            throw new ParseException(Status.MESSAGE_CONSTRAINTS);
+        }
+        return new Status(status);
     }
 
     /**

--- a/src/main/java/spleetwaise/transaction/model/FilterCommandPredicate.java
+++ b/src/main/java/spleetwaise/transaction/model/FilterCommandPredicate.java
@@ -7,6 +7,7 @@ import spleetwaise.address.model.person.Person;
 import spleetwaise.transaction.model.transaction.Amount;
 import spleetwaise.transaction.model.transaction.Date;
 import spleetwaise.transaction.model.transaction.Description;
+import spleetwaise.transaction.model.transaction.Status;
 import spleetwaise.transaction.model.transaction.Transaction;
 
 /**
@@ -18,6 +19,7 @@ public class FilterCommandPredicate implements Predicate<Transaction> {
     private final Amount amount;
     private final Description description;
     private final Date date;
+    private final Status status;
 
     /**
      * Constructs a {@code FilterCommandPredicate} with the given contact, amount, description and date.
@@ -26,9 +28,10 @@ public class FilterCommandPredicate implements Predicate<Transaction> {
      * @param amount      The amount to filter the transaction by.
      * @param description The description to filter the transaction by.
      * @param date        The date to filter the transaction by.
+     * @param status      The status to filter the transaction by.
      */
-    public FilterCommandPredicate(Person contact, Amount amount, Description description, Date date) {
-        if (contact == null && amount == null && description == null && date == null) {
+    public FilterCommandPredicate(Person contact, Amount amount, Description description, Date date, Status status) {
+        if (contact == null && amount == null && description == null && date == null && status == null) {
             throw new NullPointerException();
         }
 
@@ -36,6 +39,7 @@ public class FilterCommandPredicate implements Predicate<Transaction> {
         this.amount = amount;
         this.description = description;
         this.date = date;
+        this.status = status;
     }
 
     @Override
@@ -55,6 +59,10 @@ public class FilterCommandPredicate implements Predicate<Transaction> {
         }
 
         if (date != null && !txn.getDate().equals(date)) {
+            return false;
+        }
+
+        if (status != null && !txn.getStatus().equals(status)) {
             return false;
         }
 
@@ -78,7 +86,9 @@ public class FilterCommandPredicate implements Predicate<Transaction> {
                 && (description == null ? otherFilterCommandPredicate.description == null
                 : description.equals(otherFilterCommandPredicate.description))
                 && (date == null ? otherFilterCommandPredicate.date == null
-                : date.equals(otherFilterCommandPredicate.date));
+                : date.equals(otherFilterCommandPredicate.date))
+                && (status == null ? otherFilterCommandPredicate.status == null
+                : status.equals(otherFilterCommandPredicate.status));
     }
 
     @Override
@@ -88,6 +98,7 @@ public class FilterCommandPredicate implements Predicate<Transaction> {
                 .add("amount", amount)
                 .add("description", description)
                 .add("date", date)
+                .add("status", status)
                 .toString();
     }
 

--- a/src/main/java/spleetwaise/transaction/model/transaction/Status.java
+++ b/src/main/java/spleetwaise/transaction/model/transaction/Status.java
@@ -1,9 +1,20 @@
 package spleetwaise.transaction.model.transaction;
 
+import static java.util.Objects.requireNonNull;
+
+import spleetwaise.address.commons.util.AppUtil;
+
 /**
  * Represents the status of a transaction, indicating whether it is done or not.
  */
 public class Status {
+
+    public static final String DONE_STATUS = "Done";
+    public static final String NOT_DONE_STATUS = "Not Done";
+
+    public static final String MESSAGE_CONSTRAINTS = "Status should be '" + DONE_STATUS + "' or '" + NOT_DONE_STATUS
+            + "'";
+
     private final boolean isDone;
 
     /**
@@ -13,6 +24,26 @@ public class Status {
      */
     public Status(boolean isDone) {
         this.isDone = isDone;
+    }
+
+    /**
+     * Constructs a {@code Status} with the specified isDoneString.
+     *
+     * @param isDoneString The string representation of the completion state.
+     */
+    public Status(String isDoneString) {
+        requireNonNull(isDoneString);
+        String isDoneStringTrimmed = isDoneString.trim();
+        AppUtil.checkArgument(isValidStatus(isDoneStringTrimmed), MESSAGE_CONSTRAINTS);
+        this.isDone = DONE_STATUS.equals(isDoneStringTrimmed);
+    }
+
+    /**
+     * Returns true if a given string is a valid status.
+     */
+    public static boolean isValidStatus(String status) {
+        String trimmedStatus = status.trim();
+        return DONE_STATUS.equals(trimmedStatus) || NOT_DONE_STATUS.equals(trimmedStatus);
     }
 
     /**
@@ -26,7 +57,7 @@ public class Status {
 
     @Override
     public String toString() {
-        return isDone ? "Done" : "Not Done";
+        return isDone ? DONE_STATUS : NOT_DONE_STATUS;
     }
 
     @Override

--- a/src/test/java/spleetwaise/transaction/logic/commands/FilterCommandTest.java
+++ b/src/test/java/spleetwaise/transaction/logic/commands/FilterCommandTest.java
@@ -23,6 +23,7 @@ import spleetwaise.transaction.model.TransactionBookModelManager;
 import spleetwaise.transaction.model.transaction.Amount;
 import spleetwaise.transaction.model.transaction.Date;
 import spleetwaise.transaction.model.transaction.Description;
+import spleetwaise.transaction.model.transaction.Status;
 import spleetwaise.transaction.testutil.TypicalTransactions;
 
 public class FilterCommandTest {
@@ -31,6 +32,7 @@ public class FilterCommandTest {
     private static final Amount testAmount = TypicalTransactions.SEANOWESME.getAmount();
     private static final Description testDescription = TypicalTransactions.SEANOWESME.getDescription();
     private static final Date testDate = TypicalTransactions.SEANOWESME.getDate();
+    private static final Status testStatus = TypicalTransactions.SEANOWESME.getStatus();
     private static final AddressBookModel abModel = new AddressBookModelManager();
     private static final TransactionBookModel txnModel = new TransactionBookModelManager();
 
@@ -55,7 +57,8 @@ public class FilterCommandTest {
 
     @Test
     public void execute_allParams_success() {
-        FilterCommandPredicate pred = new FilterCommandPredicate(testPerson, testAmount, testDescription, testDate);
+        FilterCommandPredicate pred = new FilterCommandPredicate(testPerson, testAmount, testDescription,
+                testDate, testStatus);
         FilterCommand cmd = new FilterCommand(pred);
         CommandResult cmdRes = assertDoesNotThrow(cmd::execute);
 
@@ -67,8 +70,10 @@ public class FilterCommandTest {
 
     @Test
     public void equals_sameTransaction_returnsTrue() {
-        FilterCommandPredicate pred1 = new FilterCommandPredicate(testPerson, testAmount, testDescription, testDate);
-        FilterCommandPredicate pred2 = new FilterCommandPredicate(testPerson, testAmount, testDescription, testDate);
+        FilterCommandPredicate pred1 = new FilterCommandPredicate(testPerson, testAmount, testDescription,
+                testDate, testStatus);
+        FilterCommandPredicate pred2 = new FilterCommandPredicate(testPerson, testAmount, testDescription,
+                testDate, testStatus);
         FilterCommand cmd1 = new FilterCommand(pred1);
         FilterCommand cmd2 = new FilterCommand(pred1);
         FilterCommand cmd3 = new FilterCommand(pred2);
@@ -80,8 +85,8 @@ public class FilterCommandTest {
 
     @Test
     public void equals_diffTransaction_returnsFalse() {
-        FilterCommandPredicate pred1 = new FilterCommandPredicate(testPerson, null, null, null);
-        FilterCommandPredicate pred2 = new FilterCommandPredicate(null, testAmount, null, null);
+        FilterCommandPredicate pred1 = new FilterCommandPredicate(testPerson, null, null, null, null);
+        FilterCommandPredicate pred2 = new FilterCommandPredicate(null, testAmount, null, null, null);
         FilterCommand cmd1 = new FilterCommand(pred1);
         FilterCommand cmd2 = new FilterCommand(pred2);
 
@@ -90,7 +95,8 @@ public class FilterCommandTest {
 
     @Test
     public void equals_genericObject_returnsFalse() {
-        FilterCommandPredicate pred = new FilterCommandPredicate(testPerson, testAmount, testDescription, testDate);
+        FilterCommandPredicate pred = new FilterCommandPredicate(testPerson, testAmount, testDescription,
+                testDate, testStatus);
         FilterCommand cmd = new FilterCommand(pred);
 
         assertNotEquals(new Object(), cmd);
@@ -98,7 +104,8 @@ public class FilterCommandTest {
 
     @Test
     public void equals_null_returnsFalse() {
-        FilterCommandPredicate pred = new FilterCommandPredicate(testPerson, testAmount, testDescription, testDate);
+        FilterCommandPredicate pred = new FilterCommandPredicate(testPerson, testAmount, testDescription,
+                testDate, testStatus);
         FilterCommand cmd = new FilterCommand(pred);
 
         assertNotEquals(null, cmd);
@@ -106,12 +113,12 @@ public class FilterCommandTest {
 
     @Test
     public void toString_success() {
-        FilterCommandPredicate pred = new FilterCommandPredicate(null, null, testDescription, null);
+        FilterCommandPredicate pred = new FilterCommandPredicate(null, null, testDescription, null, null);
         FilterCommand cmd = new FilterCommand(pred);
         assertEquals(
                 "spleetwaise.transaction.logic.commands.FilterCommand{predicate=spleetwaise.transaction.model"
                         + ".FilterCommandPredicate{contact=null, amount=null, description=Sean owes me a lot for a "
-                        + "landed property in Sentosa, date=null}}",
+                        + "landed property in Sentosa, date=null, status=null}}",
                 cmd.toString()
         );
     }

--- a/src/test/java/spleetwaise/transaction/logic/parser/FilterCommandParserTest.java
+++ b/src/test/java/spleetwaise/transaction/logic/parser/FilterCommandParserTest.java
@@ -21,6 +21,7 @@ import spleetwaise.transaction.model.TransactionBookModelManager;
 import spleetwaise.transaction.model.transaction.Amount;
 import spleetwaise.transaction.model.transaction.Date;
 import spleetwaise.transaction.model.transaction.Description;
+import spleetwaise.transaction.model.transaction.Status;
 import spleetwaise.transaction.testutil.TypicalTransactions;
 
 public class FilterCommandParserTest {
@@ -29,6 +30,7 @@ public class FilterCommandParserTest {
     private static final Amount testAmount = TypicalTransactions.SEANOWESME.getAmount();
     private static final Description testDescription = TypicalTransactions.SEANOWESME.getDescription();
     private static final Date testDate = TypicalTransactions.SEANOWESME.getDate();
+    private static final Status testStatus = TypicalTransactions.SEANOWESME.getStatus();
     private static final AddressBookModel abModel = new AddressBookModelManager();
     private static final TransactionBookModel txnModel = new TransactionBookModelManager();
 
@@ -44,7 +46,7 @@ public class FilterCommandParserTest {
     @Test
     public void parse_personField_success() {
         String userInput = " 1";
-        FilterCommandPredicate expectedPred = new FilterCommandPredicate(testPerson, null, null, null);
+        FilterCommandPredicate expectedPred = new FilterCommandPredicate(testPerson, null, null, null, null);
 
         assertParseSuccess(parser, userInput, new FilterCommand(expectedPred));
     }
@@ -52,7 +54,7 @@ public class FilterCommandParserTest {
     @Test
     public void parse_amountField_success() {
         String userInput = " amt/9999999999.99";
-        FilterCommandPredicate expectedPred = new FilterCommandPredicate(null, testAmount, null, null);
+        FilterCommandPredicate expectedPred = new FilterCommandPredicate(null, testAmount, null, null, null);
 
         assertParseSuccess(parser, userInput, new FilterCommand(expectedPred));
     }
@@ -60,7 +62,7 @@ public class FilterCommandParserTest {
     @Test
     public void parse_descriptionField_success() {
         String userInput = " desc/Sean owes me a lot for a landed property in Sentosa";
-        FilterCommandPredicate expectedPred = new FilterCommandPredicate(null, null, testDescription, null);
+        FilterCommandPredicate expectedPred = new FilterCommandPredicate(null, null, testDescription, null, null);
 
         assertParseSuccess(parser, userInput, new FilterCommand(expectedPred));
     }
@@ -68,7 +70,15 @@ public class FilterCommandParserTest {
     @Test
     public void parse_dateField_success() {
         String userInput = " date/10102024";
-        FilterCommandPredicate expectedPred = new FilterCommandPredicate(null, null, null, testDate);
+        FilterCommandPredicate expectedPred = new FilterCommandPredicate(null, null, null, testDate, null);
+
+        assertParseSuccess(parser, userInput, new FilterCommand(expectedPred));
+    }
+
+    @Test
+    public void parse_statusField_success() {
+        String userInput = " status/" + Status.NOT_DONE_STATUS;
+        FilterCommandPredicate expectedPred = new FilterCommandPredicate(null, null, null, null, testStatus);
 
         assertParseSuccess(parser, userInput, new FilterCommand(expectedPred));
     }
@@ -76,9 +86,10 @@ public class FilterCommandParserTest {
     @Test
     public void parse_allFields_success() {
         String userInput = " 1 amt/9999999999.99  "
-                + "desc/Sean owes me a lot for a landed property in Sentosa date/10102024";
+                + "desc/Sean owes me a lot for a landed property in Sentosa date/10102024 status/"
+                + Status.NOT_DONE_STATUS;
         FilterCommandPredicate expectedPred = new FilterCommandPredicate(testPerson, testAmount,
-                testDescription, testDate);
+                testDescription, testDate, testStatus);
 
         assertParseSuccess(parser, userInput, new FilterCommand(expectedPred));
     }
@@ -117,5 +128,11 @@ public class FilterCommandParserTest {
     public void parse_invalidDateField_failure() {
         String userInput = " date/1010202";
         assertParseFailure(parser, userInput, Date.MESSAGE_CONSTRAINTS);
+    }
+
+    @Test
+    public void parse_invalidStatusField_failure() {
+        String userInput = " status/invalid";
+        assertParseFailure(parser, userInput, Status.MESSAGE_CONSTRAINTS);
     }
 }

--- a/src/test/java/spleetwaise/transaction/logic/parser/ParserUtilTest.java
+++ b/src/test/java/spleetwaise/transaction/logic/parser/ParserUtilTest.java
@@ -20,6 +20,7 @@ import spleetwaise.commons.model.CommonModel;
 import spleetwaise.transaction.model.transaction.Amount;
 import spleetwaise.transaction.model.transaction.Date;
 import spleetwaise.transaction.model.transaction.Description;
+import spleetwaise.transaction.model.transaction.Status;
 
 public class ParserUtilTest {
     private static final String INVALID_AMOUNT = "+123.456";
@@ -30,6 +31,8 @@ public class ParserUtilTest {
 
     private static final String INVALID_DATE = "112024";
     private static final String VALID_DATE = "01012024";
+
+    private static final String INVALID_STATUS = "invalid";
 
     private static final Phone TEST_PHONE = TypicalPersons.ALICE.getPhone();
     private static final Index TEST_INDEX = Index.fromOneBased(1);
@@ -80,6 +83,27 @@ public class ParserUtilTest {
     public void parseDate_validDate_success() {
         Date result = assertDoesNotThrow(() -> ParserUtil.parseDate(VALID_DATE));
         assertEquals(new Date("01012024"), result);
+    }
+
+    @Test
+    public void parseStatus_null_exceptionThrown() {
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseStatus(null));
+    }
+
+    @Test
+    public void parseStatus_invalidStatus_exceptionThrown() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseStatus(INVALID_STATUS));
+    }
+
+    @Test
+    public void parseStatus_validStatus_success() {
+        Status result = assertDoesNotThrow(() -> ParserUtil.parseStatus(Status.DONE_STATUS));
+        assertEquals(new Status(Status.DONE_STATUS), result);
+        assertEquals(new Status(true), result);
+
+        result = assertDoesNotThrow(() -> ParserUtil.parseStatus(Status.NOT_DONE_STATUS));
+        assertEquals(new Status(Status.NOT_DONE_STATUS), result);
+        assertEquals(new Status(false), result);
     }
 
     @Test

--- a/src/test/java/spleetwaise/transaction/model/FilterCommandPredicateTest.java
+++ b/src/test/java/spleetwaise/transaction/model/FilterCommandPredicateTest.java
@@ -12,6 +12,7 @@ import spleetwaise.address.model.person.Person;
 import spleetwaise.transaction.model.transaction.Amount;
 import spleetwaise.transaction.model.transaction.Date;
 import spleetwaise.transaction.model.transaction.Description;
+import spleetwaise.transaction.model.transaction.Status;
 import spleetwaise.transaction.testutil.TypicalTransactions;
 
 public class FilterCommandPredicateTest {
@@ -19,15 +20,16 @@ public class FilterCommandPredicateTest {
     private static final Amount testAmount = TypicalTransactions.SEANOWESME.getAmount();
     private static final Description testDescription = TypicalTransactions.SEANOWESME.getDescription();
     private static final Date testDate = TypicalTransactions.SEANOWESME.getDate();
+    private static final Status tesStatus = TypicalTransactions.SEANOWESME.getStatus();
 
     @Test
     public void constructor_null_exceptionThrown() {
-        assertThrows(NullPointerException.class, () -> new FilterCommandPredicate(null, null, null, null));
+        assertThrows(NullPointerException.class, () -> new FilterCommandPredicate(null, null, null, null, null));
     }
 
     @Test
     public void execute_personOnly_success() {
-        FilterCommandPredicate pred = new FilterCommandPredicate(testPerson, null, null, null);
+        FilterCommandPredicate pred = new FilterCommandPredicate(testPerson, null, null, null, null);
 
         assertTrue(pred.test(TypicalTransactions.SEANOWESME));
         assertFalse(pred.test(TypicalTransactions.BOBOWES));
@@ -35,7 +37,7 @@ public class FilterCommandPredicateTest {
 
     @Test
     public void execute_amountOnly_success() {
-        FilterCommandPredicate pred = new FilterCommandPredicate(null, testAmount, null, null);
+        FilterCommandPredicate pred = new FilterCommandPredicate(null, testAmount, null, null, null);
 
         assertTrue(pred.test(TypicalTransactions.SEANOWESME));
         assertFalse(pred.test(TypicalTransactions.BOBOWES));
@@ -43,7 +45,7 @@ public class FilterCommandPredicateTest {
 
     @Test
     public void execute_descriptionOnly_success() {
-        FilterCommandPredicate pred = new FilterCommandPredicate(null, null, testDescription, null);
+        FilterCommandPredicate pred = new FilterCommandPredicate(null, null, testDescription, null, null);
 
         assertTrue(pred.test(TypicalTransactions.SEANOWESME));
         assertFalse(pred.test(TypicalTransactions.BOBOWES));
@@ -52,7 +54,7 @@ public class FilterCommandPredicateTest {
     @Test
     public void execute_descriptionDifferentCaseOnly_success() {
         FilterCommandPredicate pred = new FilterCommandPredicate(null, null,
-                new Description(testDescription.toString().toLowerCase()), null
+                new Description(testDescription.toString().toLowerCase()), null, null
         );
 
         assertTrue(pred.test(TypicalTransactions.SEANOWESME));
@@ -61,7 +63,15 @@ public class FilterCommandPredicateTest {
 
     @Test
     public void execute_dateOnly_success() {
-        FilterCommandPredicate pred = new FilterCommandPredicate(null, null, null, testDate);
+        FilterCommandPredicate pred = new FilterCommandPredicate(null, null, null, testDate, null);
+
+        assertTrue(pred.test(TypicalTransactions.SEANOWESME));
+        assertFalse(pred.test(TypicalTransactions.BOBOWES));
+    }
+
+    @Test
+    public void execute_statusOnly_success() {
+        FilterCommandPredicate pred = new FilterCommandPredicate(null, null, null, null, tesStatus);
 
         assertTrue(pred.test(TypicalTransactions.SEANOWESME));
         assertFalse(pred.test(TypicalTransactions.BOBOWES));
@@ -69,7 +79,8 @@ public class FilterCommandPredicateTest {
 
     @Test
     public void execute_allParams_success() {
-        FilterCommandPredicate pred = new FilterCommandPredicate(testPerson, testAmount, testDescription, testDate);
+        FilterCommandPredicate pred = new FilterCommandPredicate(testPerson, testAmount, testDescription,
+                testDate, tesStatus);
 
         assertTrue(pred.test(TypicalTransactions.SEANOWESME));
         assertFalse(pred.test(TypicalTransactions.BOBOWES));
@@ -77,8 +88,10 @@ public class FilterCommandPredicateTest {
 
     @Test
     public void equals_samePredicate_returnsTrue() {
-        FilterCommandPredicate pred1 = new FilterCommandPredicate(testPerson, testAmount, testDescription, testDate);
-        FilterCommandPredicate pred2 = new FilterCommandPredicate(testPerson, testAmount, testDescription, testDate);
+        FilterCommandPredicate pred1 = new FilterCommandPredicate(testPerson, testAmount, testDescription,
+                testDate, tesStatus);
+        FilterCommandPredicate pred2 = new FilterCommandPredicate(testPerson, testAmount, testDescription,
+                testDate, tesStatus);
 
         assertEquals(pred1, pred1);
         assertEquals(pred1, pred2);
@@ -86,39 +99,51 @@ public class FilterCommandPredicateTest {
 
     @Test
     public void equals_diffPredicate_returnsFalse() {
-        FilterCommandPredicate pred1 = new FilterCommandPredicate(null, testAmount, testDescription, testDate);
-        FilterCommandPredicate pred2 = new FilterCommandPredicate(testPerson, null, testDescription, testDate);
-        FilterCommandPredicate pred3 = new FilterCommandPredicate(testPerson, testAmount, null, testDate);
-        FilterCommandPredicate pred4 = new FilterCommandPredicate(testPerson, testAmount, testDescription, null);
+        FilterCommandPredicate pred1 = new FilterCommandPredicate(null, testAmount, testDescription,
+                testDate, tesStatus);
+        FilterCommandPredicate pred2 = new FilterCommandPredicate(testPerson, null, testDescription,
+                testDate, tesStatus);
+        FilterCommandPredicate pred3 = new FilterCommandPredicate(testPerson, testAmount, null,
+                testDate, tesStatus);
+        FilterCommandPredicate pred4 = new FilterCommandPredicate(testPerson, testAmount, testDescription,
+                null, tesStatus);
+        FilterCommandPredicate pred5 = new FilterCommandPredicate(testPerson, testAmount, testDescription,
+                testDate, null);
 
         assertNotEquals(pred1, pred2);
         assertNotEquals(pred1, pred3);
         assertNotEquals(pred1, pred4);
+        assertNotEquals(pred1, pred5);
         assertNotEquals(pred2, pred3);
         assertNotEquals(pred2, pred4);
+        assertNotEquals(pred2, pred5);
         assertNotEquals(pred3, pred4);
+        assertNotEquals(pred3, pred5);
+        assertNotEquals(pred4, pred5);
     }
 
     @Test
     public void equals_genericObject_returnsFalse() {
-        FilterCommandPredicate pred = new FilterCommandPredicate(testPerson, testAmount, testDescription, testDate);
+        FilterCommandPredicate pred = new FilterCommandPredicate(testPerson, testAmount, testDescription,
+                testDate, tesStatus);
 
         assertNotEquals(new Object(), pred);
     }
 
     @Test
     public void equals_null_returnsFalse() {
-        FilterCommandPredicate pred = new FilterCommandPredicate(testPerson, testAmount, testDescription, testDate);
+        FilterCommandPredicate pred = new FilterCommandPredicate(testPerson, testAmount, testDescription,
+                testDate, tesStatus);
 
         assertNotEquals(null, pred);
     }
 
     @Test
     public void toString_success() {
-        FilterCommandPredicate pred = new FilterCommandPredicate(null, null, testDescription, null);
+        FilterCommandPredicate pred = new FilterCommandPredicate(null, null, testDescription, null, null);
         assertEquals(
                 "spleetwaise.transaction.model.FilterCommandPredicate{contact=null, amount=null, "
-                        + "description=Sean owes me a lot for a landed property in Sentosa, date=null}",
+                        + "description=Sean owes me a lot for a landed property in Sentosa, date=null, status=null}",
                 pred.toString()
         );
     }

--- a/src/test/java/spleetwaise/transaction/model/transaction/StatusTest.java
+++ b/src/test/java/spleetwaise/transaction/model/transaction/StatusTest.java
@@ -1,0 +1,101 @@
+package spleetwaise.transaction.model.transaction;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class StatusTest {
+
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        String testString = null;
+
+        assertThrows(NullPointerException.class, () -> new Status(testString));
+    }
+
+    @Test
+    public void constructor_empty_throwsIllegalArgumentException() {
+        String testString = "";
+
+        assertThrows(IllegalArgumentException.class, () -> new Status(testString));
+    }
+
+    @Test
+    public void constructor_validInput_success() {
+        assertDoesNotThrow(() -> new Status(Status.DONE_STATUS));
+        assertDoesNotThrow(() -> new Status(Status.NOT_DONE_STATUS));
+        assertDoesNotThrow(() -> new Status(true));
+        assertDoesNotThrow(() -> new Status(false));
+    }
+
+    @Test
+    public void isDone_returnCorrectOutput() {
+        assertTrue(new Status(Status.DONE_STATUS).isDone());
+        assertFalse(new Status(Status.NOT_DONE_STATUS).isDone());
+    }
+
+    @Test
+    public void isValidStatus_validInput_returnsTrue() {
+        assertTrue(Status.isValidStatus(Status.DONE_STATUS));
+        assertTrue(Status.isValidStatus(Status.NOT_DONE_STATUS));
+    }
+
+    @Test
+    public void isValidStatus_invalidInput_returnsFalse() {
+        assertFalse(Status.isValidStatus(""));
+        assertFalse(Status.isValidStatus(" "));
+        assertFalse(Status.isValidStatus("done"));
+        assertFalse(Status.isValidStatus("not done"));
+        assertFalse(Status.isValidStatus("not done "));
+        assertFalse(Status.isValidStatus(" done"));
+        assertFalse(Status.isValidStatus("not done "));
+        assertFalse(Status.isValidStatus("invalid"));
+    }
+
+    @Test
+    public void equals_validArgument_returnsTrue() {
+        Status status = new Status(Status.DONE_STATUS);
+        Status status2 = new Status(Status.DONE_STATUS);
+        Status status3 = new Status(true);
+        assertEquals(status, status);
+        assertEquals(status, status2);
+        assertEquals(status, status3);
+
+        status = new Status(Status.NOT_DONE_STATUS);
+        status2 = new Status(Status.NOT_DONE_STATUS);
+        status3 = new Status(false);
+        assertEquals(status, status);
+        assertEquals(status, status2);
+        assertEquals(status, status3);
+    }
+
+    @Test
+    public void equals_invalidArgument_returnsFalse() {
+        Status status = new Status(Status.DONE_STATUS);
+        Status status2 = new Status(true);
+        Status status3 = new Status(Status.NOT_DONE_STATUS);
+        Status status4 = new Status(false);
+
+        assertNotEquals(status, null);
+        assertNotEquals(status, new Object());
+        assertNotEquals(status, status3);
+        assertNotEquals(status, status4);
+        assertNotEquals(status2, status3);
+        assertNotEquals(status2, status4);
+
+
+    }
+
+    @Test
+    public void toString_returnsCorrectOutput() {
+        Status status = new Status(Status.DONE_STATUS);
+        assertEquals(Status.DONE_STATUS, status.toString());
+        status = new Status(Status.NOT_DONE_STATUS);
+        assertEquals(Status.NOT_DONE_STATUS, status.toString());
+    }
+}


### PR DESCRIPTION
This PR allows the `filterTxn` command to support filtering by status of an transaction via the `status/` prefix.
Resolves #247 