### PR TITLE
Refactor `userPrefs` to common model

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -149,7 +149,7 @@ The following activity diagram summarizes what happens when a user executes a ne
 
 **Aspect: spleetwaise.commons Package:**
 
-- **Disclaimer:** Our team has decided to add the `spleetwaise.commons` package as a common package for classes that are used by multiple components, in our case, `address` and `transaction`. This is an enhancement for modularity on top of the original design of the AddressBook-Level3 project, which only have a `seedu.address` package. The refactoring is almost 90% complete, and we are working on the remaining 10% (e.g. userPrefs is still being handled by the AddressBookModelManager only).
+- **Disclaimer:** Our team has decided to add the `spleetwaise.commons` package as a common package for classes that are used by multiple components, in our case, `address` and `transaction`. This is an enhancement for modularity on top of the original design of the AddressBook-Level3 project, which only have a `seedu.address` package. The refactoring is almost 90% complete, and we are working on the remaining 10%.
 
 _{more aspects and alternatives to be added}_
 

--- a/src/main/java/spleetwaise/address/model/AddressBookModel.java
+++ b/src/main/java/spleetwaise/address/model/AddressBookModel.java
@@ -1,15 +1,12 @@
 package spleetwaise.address.model;
 
-import java.nio.file.Path;
 import java.util.Optional;
 import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import spleetwaise.address.model.person.Person;
 import spleetwaise.address.model.person.Phone;
-import spleetwaise.commons.core.GuiSettings;
 import spleetwaise.commons.core.index.Index;
-import spleetwaise.commons.model.ReadOnlyUserPrefs;
 
 /**
  * The API of the Model component.
@@ -18,35 +15,6 @@ public interface AddressBookModel {
     /** {@code Predicate} that always evaluate to true */
     Predicate<Person> PREDICATE_SHOW_ALL_PERSONS = unused -> true;
 
-    /**
-     * Returns the user prefs.
-     */
-    ReadOnlyUserPrefs getUserPrefs();
-
-    /**
-     * Replaces user prefs data with the data in {@code userPrefs}.
-     */
-    void setUserPrefs(ReadOnlyUserPrefs userPrefs);
-
-    /**
-     * Returns the user prefs' GUI settings.
-     */
-    GuiSettings getGuiSettings();
-
-    /**
-     * Sets the user prefs' GUI settings.
-     */
-    void setGuiSettings(GuiSettings guiSettings);
-
-    /**
-     * Returns the user prefs' address book file path.
-     */
-    Path getAddressBookFilePath();
-
-    /**
-     * Sets the user prefs' address book file path.
-     */
-    void setAddressBookFilePath(Path addressBookFilePath);
 
     /** Returns the AddressBook */
     ReadOnlyAddressBook getAddressBook();

--- a/src/main/java/spleetwaise/address/model/AddressBookModelManager.java
+++ b/src/main/java/spleetwaise/address/model/AddressBookModelManager.java
@@ -3,7 +3,6 @@ package spleetwaise.address.model;
 import static java.util.Objects.requireNonNull;
 import static spleetwaise.commons.util.CollectionUtil.requireAllNonNull;
 
-import java.nio.file.Path;
 import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
@@ -12,11 +11,8 @@ import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import spleetwaise.address.model.person.Person;
 import spleetwaise.address.model.person.Phone;
-import spleetwaise.commons.core.GuiSettings;
 import spleetwaise.commons.core.LogsCenter;
 import spleetwaise.commons.core.index.Index;
-import spleetwaise.commons.model.ReadOnlyUserPrefs;
-import spleetwaise.commons.model.UserPrefs;
 
 /**
  * Represents the in-memory model of the address book data.
@@ -26,60 +22,23 @@ public class AddressBookModelManager implements AddressBookModel {
     private static final Logger logger = LogsCenter.getLogger(AddressBookModelManager.class);
 
     private final AddressBook addressBook;
-    private final UserPrefs userPrefs;
     private final FilteredList<Person> filteredPersons;
 
     /**
      * Initializes a AddressBookModelManager with the given addressBook and userPrefs.
      */
-    public AddressBookModelManager(ReadOnlyAddressBook addressBook, ReadOnlyUserPrefs userPrefs) {
-        requireAllNonNull(addressBook, userPrefs);
+    public AddressBookModelManager(ReadOnlyAddressBook addressBook) {
+        requireAllNonNull(addressBook);
 
         logger.fine(
-                "Initializing AddressBook Model with address book: " + addressBook + " and user prefs " + userPrefs);
+                "Initializing AddressBook Model with address book: " + addressBook);
 
         this.addressBook = new AddressBook(addressBook);
-        this.userPrefs = new UserPrefs(userPrefs);
         filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
     }
 
     public AddressBookModelManager() {
-        this(new AddressBook(), new UserPrefs());
-    }
-
-    //=========== UserPrefs ==================================================================================
-
-    @Override
-    public ReadOnlyUserPrefs getUserPrefs() {
-        return userPrefs;
-    }
-
-    @Override
-    public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
-        requireNonNull(userPrefs);
-        this.userPrefs.resetData(userPrefs);
-    }
-
-    @Override
-    public GuiSettings getGuiSettings() {
-        return userPrefs.getGuiSettings();
-    }
-
-    @Override
-    public void setGuiSettings(GuiSettings guiSettings) {
-        requireNonNull(guiSettings);
-        userPrefs.setGuiSettings(guiSettings);
-    }
-
-    @Override
-    public Path getAddressBookFilePath() {
-        return userPrefs.getAddressBookFilePath();
-    }
-
-    @Override
-    public void setAddressBookFilePath(Path addressBookFilePath) {
-        requireNonNull(addressBookFilePath);
-        userPrefs.setAddressBookFilePath(addressBookFilePath);
+        this(new AddressBook());
     }
 
     //=========== AddressBook ================================================================================
@@ -172,7 +131,6 @@ public class AddressBookModelManager implements AddressBookModel {
 
         AddressBookModelManager otherModelManager = (AddressBookModelManager) other;
         return addressBook.equals(otherModelManager.addressBook)
-                && userPrefs.equals(otherModelManager.userPrefs)
                 && filteredPersons.equals(otherModelManager.filteredPersons);
     }
 

--- a/src/main/java/spleetwaise/commons/MainApp.java
+++ b/src/main/java/spleetwaise/commons/MainApp.java
@@ -25,7 +25,6 @@ import spleetwaise.commons.exceptions.DataLoadingException;
 import spleetwaise.commons.logic.Logic;
 import spleetwaise.commons.logic.LogicManager;
 import spleetwaise.commons.model.CommonModel;
-import spleetwaise.commons.model.ReadOnlyUserPrefs;
 import spleetwaise.commons.model.UserPrefs;
 import spleetwaise.commons.storage.JsonUserPrefsStorage;
 import spleetwaise.commons.storage.Storage;
@@ -54,7 +53,6 @@ public class MainApp extends Application {
     protected Ui ui;
     protected Logic logic;
     protected Storage storage;
-    protected CommonModel model;
 
     protected AddressBookModel addressBookModel;
     protected TransactionBookModel transactionBookModel;
@@ -77,11 +75,11 @@ public class MainApp extends Application {
                 new JsonTransactionBookStorage(userPrefs.getTransactionBookFilePath());
         storage = new StorageManager(addressBookStorage, userPrefsStorage, transactionBookStorage);
 
-        addressBookModel = initAddressBookModelManager(storage, userPrefs);
+        addressBookModel = initAddressBookModelManager(storage);
         transactionBookModel = initTransactionModelManager(storage, addressBookModel);
 
         // Initialise Common Model
-        CommonModel.initialise(addressBookModel, transactionBookModel);
+        CommonModel.initialise(addressBookModel, transactionBookModel, userPrefs);
 
         logic = new LogicManager(storage);
 
@@ -103,7 +101,7 @@ public class MainApp extends Application {
      * book is not found, or an empty address book will be used instead if errors occur when reading {@code storage}'s
      * address book.
      */
-    private AddressBookModel initAddressBookModelManager(Storage storage, ReadOnlyUserPrefs userPrefs) {
+    private AddressBookModel initAddressBookModelManager(Storage storage) {
         logger.info("Using data file : " + storage.getAddressBookFilePath());
 
         Optional<ReadOnlyAddressBook> addressBookOptional;
@@ -121,7 +119,7 @@ public class MainApp extends Application {
             initialData = new AddressBook();
         }
 
-        return new AddressBookModelManager(initialData, userPrefs);
+        return new AddressBookModelManager(initialData);
     }
 
     private TransactionBookModel initTransactionModelManager(Storage storage, AddressBookModel addressBookModel) {
@@ -227,7 +225,7 @@ public class MainApp extends Application {
     public void stop() {
         logger.info("============================ [ Stopping SpleetWaise ] =============================");
         try {
-            storage.saveUserPrefs(addressBookModel.getUserPrefs());
+            storage.saveUserPrefs(CommonModel.getInstance().getUserPrefs());
             storage.saveAddressBook(addressBookModel.getAddressBook());
             storage.saveTransactionBook(transactionBookModel.getTransactionBook());
         } catch (AccessDeniedException e) {

--- a/src/main/java/spleetwaise/commons/model/CommonModel.java
+++ b/src/main/java/spleetwaise/commons/model/CommonModel.java
@@ -25,12 +25,14 @@ public class CommonModel implements Model {
     // Singleton instance
     private static CommonModel model = null;
 
+    private final UserPrefs userPrefs;
     private AddressBookModel addressBookModel;
     private TransactionBookModel transactionBookModel;
 
-    private CommonModel(AddressBookModel abModel, TransactionBookModel tbModel) {
+    private CommonModel(AddressBookModel abModel, TransactionBookModel tbModel, ReadOnlyUserPrefs userPrefs) {
         addressBookModel = abModel;
         transactionBookModel = tbModel;
+        this.userPrefs = new UserPrefs(userPrefs);
     }
 
     public static synchronized CommonModel getInstance() {
@@ -43,9 +45,16 @@ public class CommonModel implements Model {
      *
      * @param abModel The address book model to use
      * @param tbModel The transaction book model to use
+     * @param userPrefs The user prefs to use
      */
+    public static synchronized void initialise(AddressBookModel abModel, TransactionBookModel tbModel,
+            ReadOnlyUserPrefs userPrefs) {
+        model = new CommonModel(abModel, tbModel, userPrefs);
+    }
+
+
     public static synchronized void initialise(AddressBookModel abModel, TransactionBookModel tbModel) {
-        model = new CommonModel(abModel, tbModel);
+        model = new CommonModel(abModel, tbModel, new UserPrefs());
     }
 
     /**
@@ -57,39 +66,35 @@ public class CommonModel implements Model {
 
     @Override
     public ReadOnlyUserPrefs getUserPrefs() {
-        requireNonNull(addressBookModel, "AddressBook model cannot be null");
-        return addressBookModel.getUserPrefs();
+        return userPrefs;
     }
 
-    // AddressBook
     @Override
     public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
-        requireNonNull(addressBookModel, "AddressBook model cannot be null");
-        addressBookModel.setUserPrefs(userPrefs);
+        requireNonNull(userPrefs);
+        this.userPrefs.resetData(userPrefs);
     }
 
     @Override
     public GuiSettings getGuiSettings() {
-        requireNonNull(addressBookModel, "AddressBook model cannot be null");
-        return addressBookModel.getGuiSettings();
+        return userPrefs.getGuiSettings();
     }
 
     @Override
     public void setGuiSettings(GuiSettings guiSettings) {
-        requireNonNull(addressBookModel, "AddressBook model cannot be null");
-        addressBookModel.setGuiSettings(guiSettings);
+        requireNonNull(guiSettings);
+        userPrefs.setGuiSettings(guiSettings);
     }
 
     @Override
     public Path getAddressBookFilePath() {
-        requireNonNull(addressBookModel, "AddressBook model cannot be null");
-        return addressBookModel.getAddressBookFilePath();
+        return userPrefs.getAddressBookFilePath();
     }
 
     @Override
     public void setAddressBookFilePath(Path addressBookFilePath) {
-        requireNonNull(addressBookModel, "AddressBook model cannot be null");
-        addressBookModel.setAddressBookFilePath(addressBookFilePath);
+        requireNonNull(addressBookFilePath);
+        userPrefs.setAddressBookFilePath(addressBookFilePath);
     }
 
     @Override

--- a/src/main/java/spleetwaise/commons/model/Model.java
+++ b/src/main/java/spleetwaise/commons/model/Model.java
@@ -1,6 +1,9 @@
 package spleetwaise.commons.model;
 
+import java.nio.file.Path;
+
 import spleetwaise.address.model.AddressBookModel;
+import spleetwaise.commons.core.GuiSettings;
 import spleetwaise.transaction.model.TransactionBookModel;
 
 /**
@@ -10,5 +13,33 @@ import spleetwaise.transaction.model.TransactionBookModel;
  * @see TransactionBookModel
  */
 public interface Model extends AddressBookModel, TransactionBookModel {
-    // Define methods that require data from both ab model and tb model here.
+    /**
+     * Returns the user prefs.
+     */
+    ReadOnlyUserPrefs getUserPrefs();
+
+    /**
+     * Replaces user prefs data with the data in {@code userPrefs}.
+     */
+    void setUserPrefs(ReadOnlyUserPrefs userPrefs);
+
+    /**
+     * Returns the user prefs' GUI settings.
+     */
+    GuiSettings getGuiSettings();
+
+    /**
+     * Sets the user prefs' GUI settings.
+     */
+    void setGuiSettings(GuiSettings guiSettings);
+
+    /**
+     * Returns the user prefs' address book file path.
+     */
+    Path getAddressBookFilePath();
+
+    /**
+     * Sets the user prefs' address book file path.
+     */
+    void setAddressBookFilePath(Path addressBookFilePath);
 }

--- a/src/test/java/spleetwaise/address/logic/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/spleetwaise/address/logic/commands/AddCommandIntegrationTest.java
@@ -10,7 +10,6 @@ import spleetwaise.address.model.person.Person;
 import spleetwaise.address.testutil.PersonBuilder;
 import spleetwaise.address.testutil.TypicalPersons;
 import spleetwaise.commons.model.CommonModel;
-import spleetwaise.commons.model.UserPrefs;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code AddCommand}.
@@ -21,7 +20,7 @@ public class AddCommandIntegrationTest {
 
     @BeforeEach
     public void setUp() {
-        model = new AddressBookModelManager(TypicalPersons.getTypicalAddressBook(), new UserPrefs());
+        model = new AddressBookModelManager(TypicalPersons.getTypicalAddressBook());
         CommonModel.initialise(model, null);
     }
 
@@ -29,7 +28,7 @@ public class AddCommandIntegrationTest {
     public void execute_newPerson_success() {
         Person validPerson = new PersonBuilder().build();
 
-        AddressBookModel expectedModel = new AddressBookModelManager(model.getAddressBook(), new UserPrefs());
+        AddressBookModel expectedModel = new AddressBookModelManager(model.getAddressBook());
         expectedModel.addPerson(validPerson);
 
         CommandTestUtil.assertCommandSuccess(new AddCommand(validPerson), model,

--- a/src/test/java/spleetwaise/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/spleetwaise/address/logic/commands/AddCommandTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Optional;
@@ -23,12 +22,10 @@ import spleetwaise.address.model.person.Phone;
 import spleetwaise.address.testutil.Assert;
 import spleetwaise.address.testutil.PersonBuilder;
 import spleetwaise.address.testutil.TypicalPersons;
-import spleetwaise.commons.core.GuiSettings;
 import spleetwaise.commons.core.index.Index;
 import spleetwaise.commons.logic.commands.CommandResult;
 import spleetwaise.commons.logic.commands.exceptions.CommandException;
 import spleetwaise.commons.model.CommonModel;
-import spleetwaise.commons.model.ReadOnlyUserPrefs;
 
 public class AddCommandTest {
 
@@ -97,36 +94,6 @@ public class AddCommandTest {
      * A default model stub that have all of the methods failing.
      */
     private class ModelStub implements AddressBookModel {
-
-        @Override
-        public ReadOnlyUserPrefs getUserPrefs() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public GuiSettings getGuiSettings() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setGuiSettings(GuiSettings guiSettings) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public Path getAddressBookFilePath() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setAddressBookFilePath(Path addressBookFilePath) {
-            throw new AssertionError("This method should not be called.");
-        }
 
         @Override
         public void addPerson(Person person) {

--- a/src/test/java/spleetwaise/address/logic/commands/ClearCommandTest.java
+++ b/src/test/java/spleetwaise/address/logic/commands/ClearCommandTest.java
@@ -7,7 +7,6 @@ import spleetwaise.address.model.AddressBookModel;
 import spleetwaise.address.model.AddressBookModelManager;
 import spleetwaise.address.testutil.TypicalPersons;
 import spleetwaise.commons.model.CommonModel;
-import spleetwaise.commons.model.UserPrefs;
 
 public class ClearCommandTest {
 
@@ -24,9 +23,9 @@ public class ClearCommandTest {
 
     @Test
     public void execute_nonEmptyAddressBook_success() {
-        AddressBookModel model = new AddressBookModelManager(TypicalPersons.getTypicalAddressBook(), new UserPrefs());
+        AddressBookModel model = new AddressBookModelManager(TypicalPersons.getTypicalAddressBook());
         AddressBookModel expectedModel = new AddressBookModelManager(
-                TypicalPersons.getTypicalAddressBook(), new UserPrefs());
+                TypicalPersons.getTypicalAddressBook());
         expectedModel.setAddressBook(new AddressBook());
 
         CommonModel.initialise(model, null);

--- a/src/test/java/spleetwaise/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/spleetwaise/address/logic/commands/DeleteCommandTest.java
@@ -17,7 +17,6 @@ import spleetwaise.address.testutil.TypicalIndexes;
 import spleetwaise.address.testutil.TypicalPersons;
 import spleetwaise.commons.core.index.Index;
 import spleetwaise.commons.model.CommonModel;
-import spleetwaise.commons.model.UserPrefs;
 import spleetwaise.transaction.model.TransactionBookModel;
 import spleetwaise.transaction.model.TransactionBookModelManager;
 import spleetwaise.transaction.model.transaction.Amount;
@@ -31,7 +30,7 @@ import spleetwaise.transaction.model.transaction.Transaction;
 public class DeleteCommandTest {
 
     private final AddressBookModel addressBookModel = new AddressBookModelManager(
-            TypicalPersons.getTypicalAddressBook(), new UserPrefs());
+            TypicalPersons.getTypicalAddressBook());
     private final TransactionBookModel transactionBookModel = new TransactionBookModelManager();
 
     @BeforeEach
@@ -51,7 +50,7 @@ public class DeleteCommandTest {
         );
 
         AddressBookModelManager expectedModel = new AddressBookModelManager(
-                addressBookModel.getAddressBook(), new UserPrefs());
+                addressBookModel.getAddressBook());
         expectedModel.deletePerson(personToDelete);
 
         CommandTestUtil.assertCommandSuccess(deleteCommand, addressBookModel, expectedMessage, expectedModel);
@@ -86,7 +85,7 @@ public class DeleteCommandTest {
         );
 
         AddressBookModel expectedModel = new AddressBookModelManager(
-                addressBookModel.getAddressBook(), new UserPrefs());
+                addressBookModel.getAddressBook());
         expectedModel.deletePerson(personToDelete);
         showNoPerson(expectedModel);
 

--- a/src/test/java/spleetwaise/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/spleetwaise/address/logic/commands/EditCommandTest.java
@@ -19,7 +19,6 @@ import spleetwaise.address.testutil.TypicalIndexes;
 import spleetwaise.address.testutil.TypicalPersons;
 import spleetwaise.commons.core.index.Index;
 import spleetwaise.commons.model.CommonModel;
-import spleetwaise.commons.model.UserPrefs;
 import spleetwaise.transaction.model.TransactionBookModelManager;
 
 /**
@@ -28,7 +27,7 @@ import spleetwaise.transaction.model.TransactionBookModelManager;
 public class EditCommandTest {
 
     private final AddressBookModel model = new AddressBookModelManager(
-            TypicalPersons.getTypicalAddressBook(), new UserPrefs());
+            TypicalPersons.getTypicalAddressBook());
 
     @BeforeEach
     void setUp() {
@@ -44,7 +43,7 @@ public class EditCommandTest {
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
 
         AddressBookModel expectedModel = new AddressBookModelManager(
-                new AddressBook(model.getAddressBook()), new UserPrefs());
+                new AddressBook(model.getAddressBook()));
         expectedModel.setPerson(model.getFilteredPersonList().get(0), editedPerson);
 
         CommandTestUtil.assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
@@ -69,7 +68,7 @@ public class EditCommandTest {
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
 
         AddressBookModel expectedModel = new AddressBookModelManager(
-                new AddressBook(model.getAddressBook()), new UserPrefs());
+                new AddressBook(model.getAddressBook()));
         expectedModel.setPerson(lastPerson, editedPerson);
 
         CommandTestUtil.assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
@@ -83,7 +82,7 @@ public class EditCommandTest {
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
 
         AddressBookModel expectedModel = new AddressBookModelManager(
-                new AddressBook(model.getAddressBook()), new UserPrefs());
+                new AddressBook(model.getAddressBook()));
 
         CommandTestUtil.assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
@@ -103,7 +102,7 @@ public class EditCommandTest {
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
 
         AddressBookModel expectedModel = new AddressBookModelManager(
-                new AddressBook(model.getAddressBook()), new UserPrefs());
+                new AddressBook(model.getAddressBook()));
         expectedModel.setPerson(model.getFilteredPersonList().get(0), editedPerson);
 
         CommandTestUtil.assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);

--- a/src/test/java/spleetwaise/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/spleetwaise/address/logic/commands/FindCommandTest.java
@@ -16,7 +16,6 @@ import spleetwaise.address.model.AddressBookModelManager;
 import spleetwaise.address.model.person.NameContainsKeywordsPredicate;
 import spleetwaise.address.testutil.TypicalPersons;
 import spleetwaise.commons.model.CommonModel;
-import spleetwaise.commons.model.UserPrefs;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code FindCommand}.
@@ -24,9 +23,9 @@ import spleetwaise.commons.model.UserPrefs;
 public class FindCommandTest {
 
     private AddressBookModel model = new AddressBookModelManager(
-            TypicalPersons.getTypicalAddressBook(), new UserPrefs());
+            TypicalPersons.getTypicalAddressBook());
     private AddressBookModel expectedModel = new AddressBookModelManager(
-            TypicalPersons.getTypicalAddressBook(), new UserPrefs());
+            TypicalPersons.getTypicalAddressBook());
 
     @BeforeEach
     void setUp() {

--- a/src/test/java/spleetwaise/address/logic/commands/ListCommandTest.java
+++ b/src/test/java/spleetwaise/address/logic/commands/ListCommandTest.java
@@ -8,7 +8,6 @@ import spleetwaise.address.model.AddressBookModelManager;
 import spleetwaise.address.testutil.TypicalIndexes;
 import spleetwaise.address.testutil.TypicalPersons;
 import spleetwaise.commons.model.CommonModel;
-import spleetwaise.commons.model.UserPrefs;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for ListCommand.
@@ -20,8 +19,8 @@ public class ListCommandTest {
 
     @BeforeEach
     public void setUp() {
-        model = new AddressBookModelManager(TypicalPersons.getTypicalAddressBook(), new UserPrefs());
-        expectedModel = new AddressBookModelManager(model.getAddressBook(), new UserPrefs());
+        model = new AddressBookModelManager(TypicalPersons.getTypicalAddressBook());
+        expectedModel = new AddressBookModelManager(model.getAddressBook());
         CommonModel.initialise(model, null);
     }
 

--- a/src/test/java/spleetwaise/address/logic/commands/RemarkCommandTest.java
+++ b/src/test/java/spleetwaise/address/logic/commands/RemarkCommandTest.java
@@ -24,7 +24,6 @@ import spleetwaise.address.model.person.Remark;
 import spleetwaise.address.testutil.PersonBuilder;
 import spleetwaise.commons.core.index.Index;
 import spleetwaise.commons.model.CommonModel;
-import spleetwaise.commons.model.UserPrefs;
 import spleetwaise.commons.util.IdUtil;
 
 /**
@@ -34,7 +33,7 @@ public class RemarkCommandTest {
 
     private static final String REMARK_STUB = "Some remark";
 
-    private final AddressBookModel model = new AddressBookModelManager(getTypicalAddressBook(), new UserPrefs());
+    private final AddressBookModel model = new AddressBookModelManager(getTypicalAddressBook());
 
     @BeforeEach
     public void setUp() {
@@ -52,7 +51,7 @@ public class RemarkCommandTest {
         String expectedMessage = String.format(RemarkCommand.MESSAGE_ADD_REMARK_SUCCESS, editedPerson);
 
         AddressBookModel expectedModel = new AddressBookModelManager(
-                new AddressBook(model.getAddressBook()), new UserPrefs());
+                new AddressBook(model.getAddressBook()));
         expectedModel.setPerson(firstPerson, editedPerson);
 
         assertCommandSuccess(remarkCommand, model, expectedMessage, expectedModel);
@@ -70,7 +69,7 @@ public class RemarkCommandTest {
         String expectedMessage = String.format(RemarkCommand.MESSAGE_DELETE_REMARK_SUCCESS, editedPerson);
 
         AddressBookModel expectedModel = new AddressBookModelManager(
-                new AddressBook(model.getAddressBook()), new UserPrefs());
+                new AddressBook(model.getAddressBook()));
         expectedModel.setPerson(firstPerson, editedPerson);
 
         assertCommandSuccess(remarkCommand, model, expectedMessage, expectedModel);
@@ -90,7 +89,7 @@ public class RemarkCommandTest {
         String expectedMessage = String.format(RemarkCommand.MESSAGE_ADD_REMARK_SUCCESS, editedPerson);
 
         AddressBookModel expectedModel = new AddressBookModelManager(
-                new AddressBook(model.getAddressBook()), new UserPrefs());
+                new AddressBook(model.getAddressBook()));
         expectedModel.setPerson(firstPerson, editedPerson);
 
         assertCommandSuccess(remarkCommand, model, expectedMessage, expectedModel);

--- a/src/test/java/spleetwaise/address/model/ModelManagerTest.java
+++ b/src/test/java/spleetwaise/address/model/ModelManagerTest.java
@@ -4,8 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Optional;
 
@@ -15,8 +13,6 @@ import spleetwaise.address.model.person.NameContainsKeywordsPredicate;
 import spleetwaise.address.testutil.AddressBookBuilder;
 import spleetwaise.address.testutil.Assert;
 import spleetwaise.address.testutil.TypicalPersons;
-import spleetwaise.commons.core.GuiSettings;
-import spleetwaise.commons.model.UserPrefs;
 
 public class ModelManagerTest {
 
@@ -24,53 +20,9 @@ public class ModelManagerTest {
 
     @Test
     public void constructor() {
-        assertEquals(new UserPrefs(), modelManager.getUserPrefs());
-        assertEquals(new GuiSettings(), modelManager.getGuiSettings());
         assertEquals(new AddressBook(), new AddressBook(modelManager.getAddressBook()));
     }
 
-    @Test
-    public void setUserPrefs_nullUserPrefs_throwsNullPointerException() {
-        Assert.assertThrows(NullPointerException.class, () -> modelManager.setUserPrefs(null));
-    }
-
-    @Test
-    public void setUserPrefs_validUserPrefs_copiesUserPrefs() {
-        UserPrefs userPrefs = new UserPrefs();
-        userPrefs.setAddressBookFilePath(Paths.get("address/book/file/path"));
-        userPrefs.setGuiSettings(new GuiSettings(1, 2, 3, 4));
-        modelManager.setUserPrefs(userPrefs);
-        assertEquals(userPrefs, modelManager.getUserPrefs());
-
-        // Modifying userPrefs should not modify modelManager's userPrefs
-        UserPrefs oldUserPrefs = new UserPrefs(userPrefs);
-        userPrefs.setAddressBookFilePath(Paths.get("new/address/book/file/path"));
-        assertEquals(oldUserPrefs, modelManager.getUserPrefs());
-    }
-
-    @Test
-    public void setGuiSettings_nullGuiSettings_throwsNullPointerException() {
-        Assert.assertThrows(NullPointerException.class, () -> modelManager.setGuiSettings(null));
-    }
-
-    @Test
-    public void setGuiSettings_validGuiSettings_setsGuiSettings() {
-        GuiSettings guiSettings = new GuiSettings(1, 2, 3, 4);
-        modelManager.setGuiSettings(guiSettings);
-        assertEquals(guiSettings, modelManager.getGuiSettings());
-    }
-
-    @Test
-    public void setAddressBookFilePath_nullPath_throwsNullPointerException() {
-        Assert.assertThrows(NullPointerException.class, () -> modelManager.setAddressBookFilePath(null));
-    }
-
-    @Test
-    public void setAddressBookFilePath_validPath_setsAddressBookFilePath() {
-        Path path = Paths.get("address/book/file/path");
-        modelManager.setAddressBookFilePath(path);
-        assertEquals(path, modelManager.getAddressBookFilePath());
-    }
 
     @Test
     public void hasPerson_nullPerson_throwsNullPointerException() {
@@ -104,11 +56,10 @@ public class ModelManagerTest {
         AddressBook addressBook = new AddressBookBuilder().withPerson(TypicalPersons.ALICE).withPerson(
                 TypicalPersons.BENSON).build();
         AddressBook differentAddressBook = new AddressBook();
-        UserPrefs userPrefs = new UserPrefs();
 
         // same values -> returns true
-        modelManager = new AddressBookModelManager(addressBook, userPrefs);
-        AddressBookModelManager modelManagerCopy = new AddressBookModelManager(addressBook, userPrefs);
+        modelManager = new AddressBookModelManager(addressBook);
+        AddressBookModelManager modelManagerCopy = new AddressBookModelManager(addressBook);
         assertTrue(modelManager.equals(modelManagerCopy));
 
         // same object -> returns true
@@ -121,19 +72,14 @@ public class ModelManagerTest {
         assertFalse(modelManager.equals(5));
 
         // different addressBook -> returns false
-        assertFalse(modelManager.equals(new AddressBookModelManager(differentAddressBook, userPrefs)));
+        assertFalse(modelManager.equals(new AddressBookModelManager(differentAddressBook)));
 
         // different filteredList -> returns false
         String[] keywords = TypicalPersons.ALICE.getName().fullName.split("\\s+");
         modelManager.updateFilteredPersonList(new NameContainsKeywordsPredicate(Arrays.asList(keywords)));
-        assertFalse(modelManager.equals(new AddressBookModelManager(addressBook, userPrefs)));
+        assertFalse(modelManager.equals(new AddressBookModelManager(addressBook)));
 
         // resets modelManager to initial state for upcoming tests
         modelManager.updateFilteredPersonList(AddressBookModel.PREDICATE_SHOW_ALL_PERSONS);
-
-        // different userPrefs -> returns false
-        UserPrefs differentUserPrefs = new UserPrefs();
-        differentUserPrefs.setAddressBookFilePath(Paths.get("differentFilePath"));
-        assertFalse(modelManager.equals(new AddressBookModelManager(addressBook, differentUserPrefs)));
     }
 }

--- a/src/test/java/spleetwaise/commons/logic/LogicManagerTest.java
+++ b/src/test/java/spleetwaise/commons/logic/LogicManagerTest.java
@@ -28,7 +28,6 @@ import spleetwaise.commons.logic.commands.CommandResult;
 import spleetwaise.commons.logic.commands.exceptions.CommandException;
 import spleetwaise.commons.logic.parser.exceptions.ParseException;
 import spleetwaise.commons.model.CommonModel;
-import spleetwaise.commons.model.UserPrefs;
 import spleetwaise.commons.storage.JsonUserPrefsStorage;
 import spleetwaise.commons.storage.StorageManager;
 import spleetwaise.commons.util.IdUtil;
@@ -67,19 +66,19 @@ public class LogicManagerTest {
 
     @Test
     public void getAddressBookFilePath() {
-        assertEquals(addressBookModel.getAddressBookFilePath(), logic.getAddressBookFilePath());
+        assertEquals(CommonModel.getInstance().getAddressBookFilePath(), logic.getAddressBookFilePath());
     }
 
     @Test
     public void getGuiSettings() {
-        assertEquals(addressBookModel.getGuiSettings(), logic.getGuiSettings());
+        assertEquals(CommonModel.getInstance().getGuiSettings(), logic.getGuiSettings());
     }
 
     @Test
     public void setGuiSettings() {
         GuiSettings settings = new GuiSettings();
         logic.setGuiSettings(settings);
-        assertEquals(addressBookModel.getGuiSettings(), settings);
+        assertEquals(CommonModel.getInstance().getGuiSettings(), settings);
     }
 
     @Test
@@ -189,7 +188,7 @@ public class LogicManagerTest {
             String expectedMessage
     ) {
         AddressBookModel expectedAddressBookModel =
-                new AddressBookModelManager(addressBookModel.getAddressBook(), new UserPrefs());
+                new AddressBookModelManager(addressBookModel.getAddressBook());
 
         TransactionBookModel expectedTransactionModel = new TransactionBookModelManager();
         assertCommandFailure(inputCommand, expectedException, expectedMessage, expectedAddressBookModel,

--- a/src/test/java/spleetwaise/commons/model/CommonModelTest.java
+++ b/src/test/java/spleetwaise/commons/model/CommonModelTest.java
@@ -3,14 +3,20 @@ package spleetwaise.commons.model;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 import org.junit.jupiter.api.Test;
 
 import spleetwaise.address.model.AddressBookModel;
 import spleetwaise.address.model.AddressBookModelManager;
+import spleetwaise.address.testutil.Assert;
+import spleetwaise.commons.core.GuiSettings;
 import spleetwaise.transaction.model.TransactionBookModel;
 import spleetwaise.transaction.model.TransactionBookModelManager;
 
 public class CommonModelTest {
+
     @Test
     void shouldBeSingleton() {
         TransactionBookModel tbModel = new TransactionBookModelManager();
@@ -24,6 +30,9 @@ public class CommonModelTest {
 
         assertEquals(x.hashCode(), y.hashCode());
         assertEquals(y.hashCode(), z.hashCode());
+
+        assertEquals(new UserPrefs(), CommonModel.getInstance().getUserPrefs());
+        assertEquals(new GuiSettings(), CommonModel.getInstance().getGuiSettings());
     }
 
     @Test
@@ -36,7 +45,55 @@ public class CommonModelTest {
     void nullInitialisation() {
         CommonModel.initialise(null, null);
         CommonModel model = CommonModel.getInstance();
-        assertThrows(NullPointerException.class, model::getUserPrefs);
+        assertThrows(NullPointerException.class, model::getAddressBook);
         assertThrows(NullPointerException.class, model::getTransactionBook);
+    }
+
+    @Test
+    public void setUserPrefs_nullUserPrefs_throwsNullPointerException() {
+        Assert.assertThrows(NullPointerException.class, () -> CommonModel.getInstance().setUserPrefs(null));
+    }
+
+    @Test
+    public void setUserPrefs_validUserPrefs_copiesUserPrefs() {
+        CommonModel.initialise(null, null);
+
+        UserPrefs userPrefs = new UserPrefs();
+        userPrefs.setAddressBookFilePath(Paths.get("address/book/file/path"));
+        userPrefs.setGuiSettings(new GuiSettings(1, 2, 3, 4));
+
+        CommonModel.getInstance().setUserPrefs(userPrefs);
+        assertEquals(userPrefs, CommonModel.getInstance().getUserPrefs());
+
+        // Modifying userPrefs should not modify modelManager's userPrefs
+        UserPrefs oldUserPrefs = new UserPrefs(userPrefs);
+        userPrefs.setAddressBookFilePath(Paths.get("new/address/book/file/path"));
+        assertEquals(oldUserPrefs, CommonModel.getInstance().getUserPrefs());
+    }
+
+    @Test
+    public void setGuiSettings_nullGuiSettings_throwsNullPointerException() {
+        Assert.assertThrows(NullPointerException.class, () -> CommonModel.getInstance().setGuiSettings(null));
+    }
+
+    @Test
+    public void setGuiSettings_validGuiSettings_setsGuiSettings() {
+        CommonModel.initialise(null, null);
+        GuiSettings guiSettings = new GuiSettings(1, 2, 3, 4);
+        CommonModel.getInstance().setGuiSettings(guiSettings);
+        assertEquals(guiSettings, CommonModel.getInstance().getGuiSettings());
+    }
+
+    @Test
+    public void setAddressBookFilePath_nullPath_throwsNullPointerException() {
+        Assert.assertThrows(NullPointerException.class, () -> CommonModel.getInstance().setAddressBookFilePath(null));
+    }
+
+    @Test
+    public void setAddressBookFilePath_validPath_setsAddressBookFilePath() {
+        CommonModel.initialise(null, null);
+        Path path = Paths.get("address/book/file/path");
+        CommonModel.getInstance().setAddressBookFilePath(path);
+        assertEquals(path, CommonModel.getInstance().getAddressBookFilePath());
     }
 }

--- a/src/test/java/spleetwaise/commons/model/CommonModelTest.java
+++ b/src/test/java/spleetwaise/commons/model/CommonModelTest.java
@@ -18,6 +18,27 @@ import spleetwaise.transaction.model.TransactionBookModelManager;
 public class CommonModelTest {
 
     @Test
+    void constructor() {
+        TransactionBookModel tbModel = new TransactionBookModelManager();
+        AddressBookModel abModel = new AddressBookModelManager();
+
+        // test constructor values
+        CommonModel.initialise(abModel, tbModel);
+        assertEquals(abModel.getAddressBook(), CommonModel.getInstance().getAddressBook());
+        assertEquals(tbModel.getTransactionBook(), CommonModel.getInstance().getTransactionBook());
+        assertEquals(new UserPrefs(), CommonModel.getInstance().getUserPrefs());
+        assertEquals(new GuiSettings(), CommonModel.getInstance().getGuiSettings());
+
+        CommonModel.initialise(abModel, tbModel, new UserPrefs());
+        assertEquals(abModel.getAddressBook(), CommonModel.getInstance().getAddressBook());
+        assertEquals(tbModel.getTransactionBook(), CommonModel.getInstance().getTransactionBook());
+        assertEquals(new UserPrefs(), CommonModel.getInstance().getUserPrefs());
+        assertEquals(new GuiSettings(), CommonModel.getInstance().getGuiSettings());
+
+        assertThrows(NullPointerException.class, () -> CommonModel.initialise(abModel, tbModel, null));
+    }
+
+    @Test
     void shouldBeSingleton() {
         TransactionBookModel tbModel = new TransactionBookModelManager();
         AddressBookModel abModel = new AddressBookModelManager();
@@ -30,9 +51,6 @@ public class CommonModelTest {
 
         assertEquals(x.hashCode(), y.hashCode());
         assertEquals(y.hashCode(), z.hashCode());
-
-        assertEquals(new UserPrefs(), CommonModel.getInstance().getUserPrefs());
-        assertEquals(new GuiSettings(), CommonModel.getInstance().getGuiSettings());
     }
 
     @Test

--- a/src/test/java/spleetwaise/transaction/logic/commands/AddCommandTest.java
+++ b/src/test/java/spleetwaise/transaction/logic/commands/AddCommandTest.java
@@ -20,7 +20,6 @@ import spleetwaise.address.testutil.TypicalPersons;
 import spleetwaise.commons.logic.commands.CommandResult;
 import spleetwaise.commons.logic.commands.exceptions.CommandException;
 import spleetwaise.commons.model.CommonModel;
-import spleetwaise.commons.model.UserPrefs;
 import spleetwaise.transaction.model.TransactionBookModelManager;
 import spleetwaise.transaction.model.transaction.Amount;
 import spleetwaise.transaction.model.transaction.Category;
@@ -43,7 +42,7 @@ public class AddCommandTest {
     @BeforeEach
     void setup() {
         CommonModel.initialise(
-                new AddressBookModelManager(TypicalPersons.getTypicalAddressBook(), new UserPrefs()),
+                new AddressBookModelManager(TypicalPersons.getTypicalAddressBook()),
                 new TransactionBookModelManager()
         );
     }

--- a/src/test/java/spleetwaise/transaction/logic/commands/EditCommandTest.java
+++ b/src/test/java/spleetwaise/transaction/logic/commands/EditCommandTest.java
@@ -11,7 +11,6 @@ import spleetwaise.address.model.AddressBookModelManager;
 import spleetwaise.address.testutil.TypicalPersons;
 import spleetwaise.commons.core.index.Index;
 import spleetwaise.commons.model.CommonModel;
-import spleetwaise.commons.model.UserPrefs;
 import spleetwaise.transaction.logic.Messages;
 import spleetwaise.transaction.logic.commands.EditCommand.EditTransactionDescriptor;
 import spleetwaise.transaction.model.TransactionBookModel;
@@ -26,7 +25,7 @@ public class EditCommandTest {
     private final TransactionBookModel tbModel = new TransactionBookModelManager(
             TypicalTransactions.getTypicalTransactionBook());
     private final AddressBookModel abModel = new AddressBookModelManager(
-            TypicalPersons.getTypicalAddressBook(), new UserPrefs());
+            TypicalPersons.getTypicalAddressBook());
 
     @BeforeEach
     void setUp() {

--- a/src/test/java/spleetwaise/transaction/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/spleetwaise/transaction/logic/parser/EditCommandParserTest.java
@@ -20,7 +20,6 @@ import spleetwaise.address.testutil.TypicalPersons;
 import spleetwaise.commons.core.index.Index;
 import spleetwaise.commons.logic.parser.exceptions.ParseException;
 import spleetwaise.commons.model.CommonModel;
-import spleetwaise.commons.model.UserPrefs;
 import spleetwaise.transaction.logic.Messages;
 import spleetwaise.transaction.logic.commands.EditCommand;
 import spleetwaise.transaction.model.TransactionBookModel;
@@ -39,7 +38,7 @@ public class EditCommandParserTest {
     private final TransactionBookModel tbModel = new TransactionBookModelManager(
             TypicalTransactions.getTypicalTransactionBook());
     private final AddressBookModel abModel = new AddressBookModelManager(
-            TypicalPersons.getTypicalAddressBook(), new UserPrefs());
+            TypicalPersons.getTypicalAddressBook());
     private EditCommandParser parser = new EditCommandParser();
 
 

--- a/src/test/java/spleetwaise/transaction/logic/parser/FilterCommandParserTest.java
+++ b/src/test/java/spleetwaise/transaction/logic/parser/FilterCommandParserTest.java
@@ -89,7 +89,8 @@ public class FilterCommandParserTest {
                 + "desc/Sean owes me a lot for a landed property in Sentosa date/10102024 status/"
                 + Status.NOT_DONE_STATUS;
         FilterCommandPredicate expectedPred = new FilterCommandPredicate(testPerson, testAmount,
-                testDescription, testDate, testStatus);
+                testDescription, testDate, testStatus
+        );
 
         assertParseSuccess(parser, userInput, new FilterCommand(expectedPred));
     }

--- a/src/test/java/spleetwaise/transaction/logic/parser/TransactionParserTest.java
+++ b/src/test/java/spleetwaise/transaction/logic/parser/TransactionParserTest.java
@@ -13,7 +13,6 @@ import spleetwaise.address.testutil.TypicalPersons;
 import spleetwaise.commons.logic.commands.Command;
 import spleetwaise.commons.logic.parser.exceptions.ParseException;
 import spleetwaise.commons.model.CommonModel;
-import spleetwaise.commons.model.UserPrefs;
 import spleetwaise.transaction.logic.commands.AddCommand;
 import spleetwaise.transaction.logic.commands.ClearCommand;
 import spleetwaise.transaction.logic.commands.EditCommand;
@@ -28,7 +27,7 @@ public class TransactionParserTest {
     private final TransactionBookModel tbModel = new TransactionBookModelManager(
             TypicalTransactions.getTypicalTransactionBook());
     private final AddressBookModel abModel = new AddressBookModelManager(
-            TypicalPersons.getTypicalAddressBook(), new UserPrefs());
+            TypicalPersons.getTypicalAddressBook());
     private final TransactionParser parser = new TransactionParser();
 
 

--- a/src/test/java/systemtests/TestApp.java
+++ b/src/test/java/systemtests/TestApp.java
@@ -132,7 +132,7 @@ public class TestApp extends MainApp {
      * @return A {@code Model} object representing the current state of the address book.
      */
     public AddressBookModel getAddrModel() {
-        AddressBookModel copy = new AddressBookModelManager((addressBookModel.getAddressBook()), new UserPrefs());
+        AddressBookModel copy = new AddressBookModelManager((addressBookModel.getAddressBook()));
         List<Person> toDisplay = addressBookModel.getFilteredPersonList();
         Optional<Predicate<Person>> predicate = toDisplay.stream()
                 .map(person -> (Predicate<Person>) other -> other.equals(person)).reduce(Predicate::or);


### PR DESCRIPTION
Closes #262 

Addresses the following comment from #261 

> Great stuff on this PR!
> 
> One additional thing you might wanna do for completeness is to refactor `AddressBookModel.[get|set]UserPrefs` to `common...Model.[get|set]UserPrefs`.
> 
> Since `UserPrefs` is now a `common` construct, it makes more sense for the common model to own it. Address book should retrieve whatever it needs from `UserPrefs` from the common model instead.

