### PR TITLE
Trim input before valid description testing

### DIFF
--- a/src/main/java/spleetwaise/transaction/logic/parser/ParserUtil.java
+++ b/src/main/java/spleetwaise/transaction/logic/parser/ParserUtil.java
@@ -50,6 +50,7 @@ public class ParserUtil extends BaseParserUtil {
     public static Description parseDescription(String description) throws ParseException {
         requireNonNull(description);
         description = description.trim();
+        description = description.replace("\\/", "/");
         if (!Description.isValidDescription(description)) {
             throw new ParseException(Description.MESSAGE_CONSTRAINTS);
         }

--- a/src/main/java/spleetwaise/transaction/model/transaction/Description.java
+++ b/src/main/java/spleetwaise/transaction/model/transaction/Description.java
@@ -27,12 +27,13 @@ public class Description {
      */
     public Description(String description) {
         requireNonNull(description);
+        description = description.trim();
         AppUtil.checkArgument(isValidDescription(description), MESSAGE_CONSTRAINTS);
-        this.description = description.trim();
+        this.description = description;
     }
 
     public static boolean isValidDescription(String testString) {
-        return !testString.isEmpty() && testString.length() < MAX_LENGTH;
+        return !testString.trim().isEmpty() && testString.trim().length() <= MAX_LENGTH;
     }
 
     @Override

--- a/src/test/java/spleetwaise/transaction/model/transaction/DescriptionTest.java
+++ b/src/test/java/spleetwaise/transaction/model/transaction/DescriptionTest.java
@@ -30,12 +30,9 @@ public class DescriptionTest {
     @Test
     public void isValidDescription_invalidInput_returnsFalse() {
         assertFalse(Description.isValidDescription(""));
+        assertFalse(Description.isValidDescription("    "));
 
-        StringBuilder longStringBuilder = new StringBuilder();
-        for (int i = 0; i <= 120; i++) {
-            longStringBuilder.append("+");
-        }
-        String longString = longStringBuilder.toString();
+        String longString = "+".repeat(Description.MAX_LENGTH + 1);
         assertFalse(Description.isValidDescription(longString));
     }
 
@@ -50,7 +47,6 @@ public class DescriptionTest {
         Description desc2 = new Description("same");
 
         assertTrue(desc1.equals(desc2));
-
         assertTrue(desc1.equals(desc1));
     }
 


### PR DESCRIPTION
If the user inputs`       ` with several whitespaces, it passes the description validation. This fixes it. Closes #260 