### PR TITLE
Fix id errors when editing from json

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -368,8 +368,7 @@ AddressBook and Transaction data are saved in the hard disk automatically after 
 - Advanced users are welcome to update data directly by editing that data file.
 
 <div markdown="span" class="alert alert-warning">:exclamation: **Caution:**
-If your changes to the data file makes its format invalid, SpleetWaise will discard all data and start with an empty data file at the next run. Hence, it is recommended to take a backup of the file before editing it.<br>
-Transactions with invalid person IDs will not be loaded into the TransactionBook.<br>
+If changes to the data file make its format invalid, SpleetWaise will discard corrupted data and start as usual. To avoid data loss, it’s recommended to back up the file before making edits. Person and Transactions with invalid fields will be discarded before the application starts.<br>
 Furthermore, certain edits can cause the AddressBook or TransactionBook to behave in unexpected ways (e.g., if a value entered is outside the acceptable range). Therefore, edit the data file only if you are confident that you can update it correctly.
 </div>
 

--- a/src/main/java/spleetwaise/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/spleetwaise/address/storage/JsonAdaptedPerson.java
@@ -17,6 +17,7 @@ import spleetwaise.address.model.person.Phone;
 import spleetwaise.address.model.person.Remark;
 import spleetwaise.address.model.tag.Tag;
 import spleetwaise.commons.exceptions.IllegalValueException;
+import spleetwaise.commons.util.IdUtil;
 
 /**
  * Jackson-friendly version of {@link Person}.
@@ -121,7 +122,11 @@ public class JsonAdaptedPerson {
         final Remark modelRemark = new Remark(remark);
 
         final Set<Tag> modelTags = new HashSet<>(personTags);
-        return new Person(id, modelName, modelPhone, modelEmail, modelAddress, modelRemark, modelTags);
-    }
 
+        if (!IdUtil.isValidId(id)) {
+            throw new IllegalValueException(IdUtil.MESSAGE_CONSTRAINTS);
+        }
+
+        return new Person(id.trim(), modelName, modelPhone, modelEmail, modelAddress, modelRemark, modelTags);
+    }
 }

--- a/src/main/java/spleetwaise/commons/util/IdUtil.java
+++ b/src/main/java/spleetwaise/commons/util/IdUtil.java
@@ -1,5 +1,7 @@
 package spleetwaise.commons.util;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.UUID;
 
 /**
@@ -7,7 +9,9 @@ import java.util.UUID;
  */
 public class IdUtil {
 
-    public static final String TEST_ID = "test-uuid";
+    public static final String TEST_ID = "123e4567-e89b-42d3-a456-556642440000";
+    public static final String MESSAGE_CONSTRAINTS = "UUID is invalid, refer to "
+            + "https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/UUID.html.";
     private static boolean isDeterminate = false;
 
     /**
@@ -32,4 +36,17 @@ public class IdUtil {
         return UUID.randomUUID().toString();
     }
 
+    /**
+     * Returns true if a given string is a valid remark (allows empty string "").
+     */
+    public static boolean isValidId(String id) {
+        try {
+            requireNonNull(id);
+            String trimmedId = id.trim();
+            UUID.fromString(trimmedId);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
 }

--- a/src/main/java/spleetwaise/transaction/storage/adapters/JsonAdaptedTransaction.java
+++ b/src/main/java/spleetwaise/transaction/storage/adapters/JsonAdaptedTransaction.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import spleetwaise.address.model.AddressBookModel;
 import spleetwaise.address.model.person.Person;
 import spleetwaise.commons.exceptions.IllegalValueException;
+import spleetwaise.commons.util.IdUtil;
 import spleetwaise.transaction.model.transaction.Amount;
 import spleetwaise.transaction.model.transaction.Category;
 import spleetwaise.transaction.model.transaction.Date;
@@ -169,6 +170,11 @@ public class JsonAdaptedTransaction {
         if (id == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, "id"));
         }
+
+        if (!IdUtil.isValidId(id)) {
+            throw new IllegalValueException(IdUtil.MESSAGE_CONSTRAINTS);
+        }
+
         if (personId == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, "personId"));
         }
@@ -204,6 +210,6 @@ public class JsonAdaptedTransaction {
         s = new Status(isDone);
         Set<Category> mc = new HashSet<>(txnCategories);
 
-        return new Transaction(id, p, a, d, dt, mc, s);
+        return new Transaction(id.trim(), p, a, d, dt, mc, s);
     }
 }

--- a/src/test/data/JsonAddressBookStorageTest/invalidAndValidPersonAddressBook.json
+++ b/src/test/data/JsonAddressBookStorageTest/invalidAndValidPersonAddressBook.json
@@ -5,14 +5,16 @@
       "name": "Valid Person",
       "phone": "9482424",
       "email": "hans@example.com",
-      "address": "4th street"
+      "address": "4th street",
+      "remark": ""
     },
     {
       "id": "3929a136-823a-4806-af62-e96b241167b5",
       "name": "Person With Invalid Phone Field",
       "phone": "948asdf2424",
       "email": "hans@example.com",
-      "address": "4th street"
+      "address": "4th street",
+      "remark": ""
     }
   ]
 }

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -2,7 +2,7 @@
   "_comment": "AddressBook save file which contains the same Person values as in TypicalPersons#getTypicalAddressBook()",
   "persons": [
     {
-      "id": "29705d8f-6a2b-4de3-8b86-e8efb3f2215f",
+      "id": "5db6c966-11cf-4f7a-82bb-535d6e6a1e4a",
       "name": "Alice Pauline",
       "phone": "94351253",
       "email": "alice@example.com",
@@ -13,7 +13,7 @@
       ]
     },
     {
-      "id": "3929a136-823a-4806-af62-e96b241167b5",
+      "id": "5db6c966-11cf-4f7a-82bb-535d6e6a1e4b",
       "name": "Benson Meier",
       "phone": "98765432",
       "email": "johnd@example.com",
@@ -25,7 +25,7 @@
       ]
     },
     {
-      "id": "60196500-3d01-4e6c-81de-44ab6fc9e7e5",
+      "id": "5db6c966-11cf-4f7a-82bb-535d6e6a1e4c",
       "name": "Carl Kurz",
       "phone": "95352563",
       "email": "heinz@example.com",
@@ -34,7 +34,7 @@
       "tags": []
     },
     {
-      "id": "b89d7c94-9823-4b6a-ae46-b7c55ee41727",
+      "id": "5db6c966-11cf-4f7a-82bb-535d6e6a1e4d",
       "name": "Daniel Meier",
       "phone": "87652533",
       "email": "cornelia@example.com",
@@ -45,7 +45,7 @@
       ]
     },
     {
-      "id": "42984eac-421f-4966-994d-6f360d7d2882",
+      "id": "5db6c966-11cf-4f7a-82bb-535d6e6a1e4e",
       "name": "Elle Meyer",
       "phone": "9482224",
       "email": "werner@example.com",
@@ -54,7 +54,7 @@
       "tags": []
     },
     {
-      "id": "c5a93d37-44fd-4f4d-964b-6f85c715d6e3",
+      "id": "5db6c966-11cf-4f7a-82bb-535d6e6a1e4f",
       "name": "Fiona Kunz",
       "phone": "9482427",
       "email": "lydia@example.com",
@@ -63,7 +63,7 @@
       "tags": []
     },
     {
-      "id": "c5a93d37-44fd-4f4d-964b-6f85c715djf93",
+      "id": "6b76c348-7794-4ae9-be28-74e4820bb224",
       "name": "George Best",
       "phone": "9482442",
       "email": "anna@example.com",

--- a/src/test/data/JsonSerializableTransactionBookTest/duplicateEntryTransactionBook.json
+++ b/src/test/data/JsonSerializableTransactionBookTest/duplicateEntryTransactionBook.json
@@ -2,7 +2,7 @@
   "transactions": [
     {
       "id": "a1314e60-7a23-41cd-8960-d29d4edc841b",
-      "personId": "29705d8f-6a2b-4de3-8b86-e8efb3f2215f",
+      "personId": "5db6c966-11cf-4f7a-82bb-535d6e6a1e4a",
       "amount": {
         "amount": "10.00"
       },
@@ -12,7 +12,7 @@
     },
     {
       "id": "a1314e60-7a23-41cd-8960-d29d4edc841b",
-      "personId": "29705d8f-6a2b-4de3-8b86-e8efb3f2215f",
+      "personId": "5db6c966-11cf-4f7a-82bb-535d6e6a1e4a",
       "amount": {
         "amount": "10.00"
       },

--- a/src/test/data/JsonSerializableTransactionBookTest/duplicateIdTransactionBook.json
+++ b/src/test/data/JsonSerializableTransactionBookTest/duplicateIdTransactionBook.json
@@ -2,7 +2,7 @@
   "transactions": [
     {
       "id": "a1314e60-7a23-41cd-8960-d29d4edc841b",
-      "personId": "29705d8f-6a2b-4de3-8b86-e8efb3f2215f",
+      "personId": "5db6c966-11cf-4f7a-82bb-535d6e6a1e4a",
       "amount": {
         "amount": "10.00"
       },
@@ -12,7 +12,7 @@
     },
     {
       "id": "a1314e60-7a23-41cd-8960-d29d4edc841b",
-      "personId": "29705d8f-6a2b-4de3-8b86-e8efb3f2215f",
+      "personId": "5db6c966-11cf-4f7a-82bb-535d6e6a1e4a",
       "amount": {
         "amount": "5.50"
       },

--- a/src/test/data/JsonSerializableTransactionBookTest/invalidEntryTransactionBook.json
+++ b/src/test/data/JsonSerializableTransactionBookTest/invalidEntryTransactionBook.json
@@ -2,7 +2,7 @@
   "transactions": [
     {
       "id": "a1314e60-7a23-41cd-8960-d29d4edc841b",
-      "personId": "29705d8f-6a2b-4de3-8b86-e8efb3f2215f",
+      "personId": "5db6c966-11cf-4f7a-82bb-535d6e6a1e4a",
       "amount": {
         "amount": "10.00"
       },
@@ -12,7 +12,7 @@
     },
     {
       "id": "e2c93a3d-44f9-4b4b-8b5f-c5cd6f98e45a",
-      "personId": "29705d8f-6a2b-4de3-8b86-e8efb3f2215f",
+      "personId": "5db6c966-11cf-4f7a-82bb-535d6e6a1e4a",
       "amount": {
         "amount": "invalid amount"
       },

--- a/src/test/data/JsonSerializableTransactionBookTest/typicalTransactionBook.json
+++ b/src/test/data/JsonSerializableTransactionBookTest/typicalTransactionBook.json
@@ -2,7 +2,7 @@
   "transactions": [
     {
       "id": "a1314e60-7a23-41cd-8960-d29d4edc841b",
-      "personId": "29705d8f-6a2b-4de3-8b86-e8efb3f2215f",
+      "personId": "5db6c966-11cf-4f7a-82bb-535d6e6a1e4a",
       "amount": {
         "amount": "9999999999.99"
       },

--- a/src/test/java/spleetwaise/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/spleetwaise/address/storage/JsonAdaptedPersonTest.java
@@ -17,6 +17,7 @@ import spleetwaise.address.model.person.Remark;
 import spleetwaise.address.testutil.TypicalPersons;
 import spleetwaise.commons.exceptions.IllegalValueException;
 import spleetwaise.commons.testutil.Assert;
+import spleetwaise.commons.util.IdUtil;
 
 public class JsonAdaptedPersonTest {
 
@@ -47,6 +48,15 @@ public class JsonAdaptedPersonTest {
         JsonAdaptedPerson person = new JsonAdaptedPerson(
                 null, VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_REMARK, VALID_TAGS);
         Assert.assertThrows(IllegalValueException.class, person::toModelType);
+    }
+
+    @Test
+    public void toModelType_invalidIdFormat_throwsIllegalValueException() {
+        // Test an invalid ID format scenario
+        JsonAdaptedPerson person = new JsonAdaptedPerson(
+                "invalid-id", VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_REMARK, VALID_TAGS);
+        String expectedMessage = IdUtil.MESSAGE_CONSTRAINTS;
+        Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test

--- a/src/test/java/spleetwaise/address/storage/JsonAddressBookStorageTest.java
+++ b/src/test/java/spleetwaise/address/storage/JsonAddressBookStorageTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -48,19 +49,24 @@ public class JsonAddressBookStorageTest {
     }
 
     @Test
-    public void readAddressBook_invalidPersonAddressBook_throwDataLoadingException() {
-        Assert.assertThrows(DataLoadingException.class, () -> readAddressBook("invalidPersonAddressBook.json"));
+    public void readAddressBook_invalidPersonAddressBook_throwDataLoadingException() throws Exception {
+        Optional<ReadOnlyAddressBook> optionalAb = readAddressBook("invalidPersonAddressBook" + ".json");
+        assert optionalAb.isPresent();
+        assertEquals(0, optionalAb.get().getPersonList().size());
     }
 
     @Test
-    public void readAddressBook_invalidAndValidPersonAddressBook_throwDataLoadingException() {
-        Assert.assertThrows(DataLoadingException.class, () -> readAddressBook("invalidAndValidPersonAddressBook.json"));
+    public void readAddressBook_invalidAndValidPersonAddressBook_throwDataLoadingException() throws Exception {
+        Optional<ReadOnlyAddressBook> optionalAb = readAddressBook("invalidAndValidPersonAddressBook.json");
+        assert optionalAb.isPresent();
+        assertEquals(1, optionalAb.get().getPersonList().size());
     }
 
     @Test
     public void readAndSaveAddressBook_allInOrder_success() throws Exception {
         Path filePath = testFolder.resolve("TempAddressBook.json");
-        AddressBook original = TypicalPersons.getTypicalAddressBook();
+        AddressBook original = new AddressBook();
+        original.addPerson(TypicalPersons.ALICE);
         JsonAddressBookStorage jsonAddressBookStorage = new JsonAddressBookStorage(filePath);
 
         // Save in new file and read back

--- a/src/test/java/spleetwaise/address/storage/JsonSerializableAddressBookTest.java
+++ b/src/test/java/spleetwaise/address/storage/JsonSerializableAddressBookTest.java
@@ -9,8 +9,6 @@ import org.junit.jupiter.api.Test;
 
 import spleetwaise.address.model.AddressBook;
 import spleetwaise.address.testutil.TypicalPersons;
-import spleetwaise.commons.exceptions.IllegalValueException;
-import spleetwaise.commons.testutil.Assert;
 import spleetwaise.commons.util.JsonUtil;
 
 public class JsonSerializableAddressBookTest {
@@ -38,7 +36,8 @@ public class JsonSerializableAddressBookTest {
                 INVALID_PERSON_FILE,
                 JsonSerializableAddressBook.class
         ).get();
-        Assert.assertThrows(IllegalValueException.class, dataFromFile::toModelType);
+        AddressBook ab = dataFromFile.toModelType();
+        assertEquals(0, ab.getPersonList().size());
     }
 
     @Test
@@ -47,9 +46,8 @@ public class JsonSerializableAddressBookTest {
                 DUPLICATE_PERSON_FILE,
                 JsonSerializableAddressBook.class
         ).get();
-        Assert.assertThrows(IllegalValueException.class, JsonSerializableAddressBook.MESSAGE_DUPLICATE_PERSON,
-                dataFromFile::toModelType
-        );
+        AddressBook ab = dataFromFile.toModelType();
+        assertEquals(1, ab.getPersonList().size());
     }
 
     @Test
@@ -58,9 +56,7 @@ public class JsonSerializableAddressBookTest {
                 DUPLICATE_ID_FILE,
                 JsonSerializableAddressBook.class
         ).get();
-        Assert.assertThrows(IllegalValueException.class, JsonSerializableAddressBook.MESSAGE_DUPLICATE_ID,
-                dataFromFile::toModelType
-        );
+        AddressBook ab = dataFromFile.toModelType();
+        assertEquals(1, ab.getPersonList().size());
     }
-
 }

--- a/src/test/java/spleetwaise/address/testutil/TypicalPersons.java
+++ b/src/test/java/spleetwaise/address/testutil/TypicalPersons.java
@@ -27,35 +27,35 @@ import spleetwaise.address.model.person.Person;
  */
 public class TypicalPersons {
 
-    public static final Person ALICE = new PersonBuilder().withId("29705d8f-6a2b-4de3-8b86-e8efb3f2215f")
+    public static final Person ALICE = new PersonBuilder().withId("5db6c966-11cf-4f7a-82bb-535d6e6a1e4a")
             .withName("Alice Pauline").withPhone("94351253").withEmail("alice@example.com")
             .withAddress("123, Jurong West Ave 6, #08-111").withRemark("alice is poor").withTags("friends").build();
-    public static final Person BENSON = new PersonBuilder().withId("3929a136-823a-4806-af62-e96b241167b5")
+    public static final Person BENSON = new PersonBuilder().withId("5db6c966-11cf-4f7a-82bb-535d6e6a1e4b")
             .withName("Benson Meier").withPhone("98765432").withEmail("johnd@example.com")
             .withAddress("311, Clementi Ave 2, #02-25").withRemark("benson is rich").withTags("owesMoney", "friends")
             .build();
-    public static final Person CARL = new PersonBuilder().withId("60196500-3d01-4e6c-81de-44ab6fc9e7e5")
+    public static final Person CARL = new PersonBuilder().withId("5db6c966-11cf-4f7a-82bb-535d6e6a1e4c")
             .withName("Carl Kurz").withPhone("95352563").withEmail("heinz@example.com").withAddress("wall street")
             .build();
-    public static final Person DANIEL = new PersonBuilder().withId("b89d7c94-9823-4b6a-ae46-b7c55ee41727")
+    public static final Person DANIEL = new PersonBuilder().withId("5db6c966-11cf-4f7a-82bb-535d6e6a1e4d")
             .withName("Daniel Meier").withPhone("87652533").withEmail("cornelia@example.com").withAddress("10th street")
             .withRemark("DANIEL IS IN DEBT").withTags("friends")
             .build();
-    public static final Person ELLE = new PersonBuilder().withId("42984eac-421f-4966-994d-6f360d7d2882")
+    public static final Person ELLE = new PersonBuilder().withId("5db6c966-11cf-4f7a-82bb-535d6e6a1e4e")
             .withName("Elle Meyer").withPhone("9482224").withEmail("werner@example.com").withAddress("michegan ave")
             .build();
-    public static final Person FIONA = new PersonBuilder().withId("c5a93d37-44fd-4f4d-964b-6f85c715d6e3")
+    public static final Person FIONA = new PersonBuilder().withId("5db6c966-11cf-4f7a-82bb-535d6e6a1e4f")
             .withName("Fiona Kunz").withPhone("9482427").withEmail("lydia@example.com").withAddress("little tokyo")
             .build();
-    public static final Person GEORGE = new PersonBuilder().withId("c5a93d37-44fd-4f4d-964b-6f85c715djf93")
+    public static final Person GEORGE = new PersonBuilder().withId("6b76c348-7794-4ae9-be28-74e4820bb224")
             .withName("George Best").withPhone("9482442").withEmail("anna@example.com").withAddress("4th street")
             .build();
 
     // Manually added
-    public static final Person HOON = new PersonBuilder().withId("c5a93d37-44fd-4f4d-964b-6f85c715djqw3")
+    public static final Person HOON = new PersonBuilder().withId("ee56885b-eca4-4c35-8587-d5d10161bade")
             .withName("Hoon Meier").withPhone("8482424").withEmail("stefan@example.com").withAddress("little india")
             .build();
-    public static final Person IDA = new PersonBuilder().withId("c5a93d37-44fd-4f4d-964b-6f85c715djgr5")
+    public static final Person IDA = new PersonBuilder().withId("ae56885b-eca4-4c35-8587-d5d10161bade")
             .withName("Ida Mueller").withPhone("8482131").withEmail("hans@example.com").withAddress("chicago ave")
             .build();
 

--- a/src/test/java/spleetwaise/commons/util/IdUtilTest.java
+++ b/src/test/java/spleetwaise/commons/util/IdUtilTest.java
@@ -1,13 +1,13 @@
 package spleetwaise.commons.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
 public class IdUtilTest {
-
-    private IdUtil idUtil = new IdUtil();
 
     @Test
     public void getId_deterministic() {
@@ -18,7 +18,17 @@ public class IdUtilTest {
 
     @Test
     public void getId_nonDeterministic() {
+        IdUtil.setDeterminate(false);
         assertNotEquals(IdUtil.TEST_ID, IdUtil.getId());
     }
 
+    @Test
+    public void isValidId_validId_returnsTrue() {
+        assertTrue(IdUtil.isValidId(IdUtil.TEST_ID));
+    }
+
+    @Test
+    public void isValidId_invalidId_returnsFalse() {
+        assertFalse(IdUtil.isValidId("invalid-uuid-format"));
+    }
 }

--- a/src/test/java/spleetwaise/transaction/storage/adapters/JsonAdaptedTransactionTest.java
+++ b/src/test/java/spleetwaise/transaction/storage/adapters/JsonAdaptedTransactionTest.java
@@ -78,8 +78,21 @@ public class JsonAdaptedTransactionTest {
     }
 
     @Test
-    public void testConstructor_invalidId() {
+    public void testConstructor_nullId() {
         JsonAdaptedTransaction jTrans = new JsonAdaptedTransaction(null, TypicalPersons.BENSON.getId(), VALID_AMT,
+                VALID_DESCRIPTION,
+                DateUtil.VALID_DATE,
+                VALID_STAT,
+                VALID_CATS
+        );
+        assertThrows(IllegalValueException.class, () -> jTrans.toModelType(addressBookModel));
+    }
+
+    @Test
+    public void testConstructor_invalidIdFormat() {
+        // Test an invalid ID format scenario
+        JsonAdaptedTransaction jTrans = new JsonAdaptedTransaction("invalid-id", TypicalPersons.BENSON.getId(),
+                VALID_AMT,
                 VALID_DESCRIPTION,
                 DateUtil.VALID_DATE,
                 VALID_STAT,


### PR DESCRIPTION
Closes #116
This pull request addresses issues related to ID validation and error handling when editing from JSON in the SpleetWaise application. The changes primarily focus on ensuring that IDs are valid UUIDs and improving the robustness of data loading from JSON files. Here are the key points of the review:

1. **ID Validation:**

   - Introduced `IdUtil.isValidId` method to validate UUIDs.
   - Added checks for valid IDs in `JsonAdaptedPerson` and `JsonAdaptedTransaction` classes.
   - Trimmed IDs before creating `Person` and `Transaction` objects to ensure no leading or trailing spaces.

2. **Error Handling:**

   - Enhanced error handling in `JsonSerializableAddressBook` to log warnings and continue processing other entries when encountering invalid data.
   - Updated test cases to reflect changes in error handling, ensuring that corrupted entries are ignored rather than causing the entire process to fail.

3. **Logging:**

   - Added logging to `JsonSerializableAddressBook` to provide more context when data corruption is detected.

4. **Test Improvements:**

   - Added new test cases to verify the behavior when invalid IDs are encountered.
   - Updated existing test cases to ensure they align with the new error handling logic.

5. **Documentation:**

   - Updated the user guide to reflect changes in how the application handles invalid data during startup.

Overall, these changes improve the application's resilience to data corruption and ensure that IDs are consistently validated across the system.