### PR TITLE
320 reset filter to reset toggle info

### DIFF
--- a/src/main/java/spleetwaise/transaction/ui/RightPanel.java
+++ b/src/main/java/spleetwaise/transaction/ui/RightPanel.java
@@ -225,7 +225,7 @@ public class RightPanel extends UiPart<Region> {
      */
     public void resetFilter() {
         statusForFilter = DONE_STATUS;
-        amountSignForFilter = NEGATIVE_SIGN;
+        amountSignForFilter = POSITIVE_SIGN;
         CommonModelManager.getInstance().updateFilteredTransactionList(TransactionBookModel.PREDICATE_SHOW_ALL_TXNS);
     }
 

--- a/src/main/java/spleetwaise/transaction/ui/RightPanel.java
+++ b/src/main/java/spleetwaise/transaction/ui/RightPanel.java
@@ -177,11 +177,11 @@ public class RightPanel extends UiPart<Region> {
         MenuItem resetFilter = new MenuItem("Reset filter");
         resetFilter.setOnAction(e -> resetFilter());
 
-        MenuItem filterByDone = new MenuItem("Filter by Done or Not Done Status");
-        filterByDone.setOnAction(e -> filterTransactionsByDoneStatus());
+        MenuItem allTxnByDoneStatus = new MenuItem("Show All Done or Not Done Transactions");
+        allTxnByDoneStatus.setOnAction(e -> showAllDoneOrNotDoneTransactions());
 
-        MenuItem filterByPositiveOrNegativeAmount = new MenuItem("Filter by Positive or Negative Amount");
-        filterByPositiveOrNegativeAmount.setOnAction(e -> filterTransactionsByAmount());
+        MenuItem allTxnByAmountSign = new MenuItem("Show All Positive or Negative Transactions");
+        allTxnByAmountSign.setOnAction(e -> showAllPositiveOrNegativeTransactions());
 
         SeparatorMenuItem divider = new SeparatorMenuItem();
 
@@ -201,33 +201,43 @@ public class RightPanel extends UiPart<Region> {
         filterByDate.setOnAction(
                 e -> commandBox.handleFilterCommandEntered(FilterCommand.COMMAND_WORD + " " + PREFIX_DATE));
 
-        filterMenu.getItems().addAll(resetFilter, filterByDone, filterByPositiveOrNegativeAmount, divider,
+        filterMenu.getItems().addAll(resetFilter, allTxnByDoneStatus, allTxnByAmountSign, divider,
                 filterByContact, filterByAmount, filterByDescription, filterByDate
         );
 
         return filterMenu;
     }
 
-    private void filterTransactionsByAmount() {
+    private void showAllPositiveOrNegativeTransactions() {
         // toggle between positive or negative amounts only
-        resetFilter();
-        CommonModelManager.getInstance()
-                .updateFilteredTransactionList(new AmountSignFilterPredicate(amountSignForFilter));
+        applyFilterOnAllTxn(new AmountSignFilterPredicate(amountSignForFilter));
         amountSignForFilter = amountSignForFilter.equals(POSITIVE_SIGN) ? NEGATIVE_SIGN : POSITIVE_SIGN;
     }
 
-    private void filterTransactionsByDoneStatus() {
-        // toggle between undone or done transactions only
-        resetFilter();
-        CommonModelManager.getInstance()
-                .updateFilteredTransactionList(new StatusFilterPredicate(new Status(statusForFilter)));
+    private void showAllDoneOrNotDoneTransactions() {
+        // toggle between done or undone transactions only
+        applyFilterOnAllTxn(new StatusFilterPredicate(new Status(statusForFilter)));
         statusForFilter = statusForFilter.equals(DONE_STATUS) ? NOT_DONE_STATUS : DONE_STATUS;
     }
 
     /**
-     * Resets the filter to show all transactions. public for testability.
+     * Resets the filter to show all transactions, and reset the toggle info. public for testability.
      */
     public void resetFilter() {
+        statusForFilter = DONE_STATUS;
+        amountSignForFilter = NEGATIVE_SIGN;
         CommonModelManager.getInstance().updateFilteredTransactionList(TransactionBookModel.PREDICATE_SHOW_ALL_TXNS);
+    }
+
+    /**
+     * Apply a filter on all transactions.
+     *
+     * @param filter the filter to apply
+     */
+    private void applyFilterOnAllTxn(Predicate<Transaction> filter) {
+        ArrayList<Predicate<Transaction>> predicates = new ArrayList<>();
+        predicates.add(TransactionBookModel.PREDICATE_SHOW_ALL_TXNS);
+        predicates.add(filter);
+        CommonModelManager.getInstance().updateFilteredTransactionList(new FilterCommandPredicate(predicates));
     }
 }

--- a/src/test/java/guitests/GuiRobot.java
+++ b/src/test/java/guitests/GuiRobot.java
@@ -14,7 +14,7 @@ import javafx.stage.Stage;
  */
 public class GuiRobot extends FxRobot {
 
-    private static final int PAUSE_FOR_HUMAN_DELAY_MILLISECONDS = 250;
+    private static final int PAUSE_FOR_HUMAN_DELAY_MILLISECONDS = 10;
     private static final int DEFAULT_WAIT_FOR_EVENT_TIMEOUT_MILLISECONDS = 5000;
 
     private static final String PROPERTY_TESTFX_HEADLESS = "testfx.headless";

--- a/src/test/java/systemtests/RightPanelTest.java
+++ b/src/test/java/systemtests/RightPanelTest.java
@@ -74,7 +74,7 @@ public class RightPanelTest {
     }
 
     @Test
-    public void testFilterTransactionsByAmount_callsResetFilterAndUpdatesPredicate()
+    public void testFilterTransactionsByAmount_callsResetShowAllPositiveOrNegativeAndUpdatesPredicate()
             throws InvocationTargetException, IllegalAccessException, NoSuchMethodException {
         // Call the private method "filterTransactionsByAmount" using reflection
         Method filterTransactionsByAmount = RightPanel.class.getDeclaredMethod("filterTransactionsByAmount");

--- a/src/test/java/systemtests/RightPanelTest.java
+++ b/src/test/java/systemtests/RightPanelTest.java
@@ -74,12 +74,13 @@ public class RightPanelTest {
     }
 
     @Test
-    public void testFilterTransactionsByAmount_callsResetShowAllPositiveOrNegativeAndUpdatesPredicate()
+    public void testShowAllPositiveOrNegativeTransactions_callsResetShowAllPositiveOrNegativeAndUpdatesPredicate()
             throws InvocationTargetException, IllegalAccessException, NoSuchMethodException {
         // Call the private method "filterTransactionsByAmount" using reflection
-        Method filterTransactionsByAmount = RightPanel.class.getDeclaredMethod("filterTransactionsByAmount");
-        filterTransactionsByAmount.setAccessible(true);
-        filterTransactionsByAmount.invoke(rightPanel);
+        Method showAllPositiveOrNegativeTransactions = RightPanel.class.getDeclaredMethod(
+                "showAllPositiveOrNegativeTransactions");
+        showAllPositiveOrNegativeTransactions.setAccessible(true);
+        showAllPositiveOrNegativeTransactions.invoke(rightPanel);
 
         verify(rightPanel, times(1)).resetFilter();
 
@@ -100,12 +101,13 @@ public class RightPanelTest {
     }
 
     @Test
-    public void testFilterTransactionsByDoneStatus_callsResetFilterAndUpdatesPredicate()
+    public void testShowAllDoneOrNotDoneTransactions_callsResetFilterAndUpdatesPredicate()
             throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
         // Call the private method "filterTransactionsByDoneStatus" using reflection
-        Method filterTransactionsByDoneStatus = RightPanel.class.getDeclaredMethod("filterTransactionsByDoneStatus");
-        filterTransactionsByDoneStatus.setAccessible(true);
-        filterTransactionsByDoneStatus.invoke(rightPanel);
+        Method showAllDoneOrNotDoneTransactions = RightPanel.class.getDeclaredMethod(
+                "showAllDoneOrNotDoneTransactions");
+        showAllDoneOrNotDoneTransactions.setAccessible(true);
+        showAllDoneOrNotDoneTransactions.invoke(rightPanel);
 
         verify(rightPanel, times(1)).resetFilter();
 

--- a/src/test/java/systemtests/RightPanelTest.java
+++ b/src/test/java/systemtests/RightPanelTest.java
@@ -74,15 +74,13 @@ public class RightPanelTest {
     }
 
     @Test
-    public void testShowAllPositiveOrNegativeTransactions_callsResetShowAllPositiveOrNegativeAndUpdatesPredicate()
+    public void testShowAllPositiveOrNegativeTransactions_updatesPredicate()
             throws InvocationTargetException, IllegalAccessException, NoSuchMethodException {
         // Call the private method "filterTransactionsByAmount" using reflection
         Method showAllPositiveOrNegativeTransactions = RightPanel.class.getDeclaredMethod(
                 "showAllPositiveOrNegativeTransactions");
         showAllPositiveOrNegativeTransactions.setAccessible(true);
         showAllPositiveOrNegativeTransactions.invoke(rightPanel);
-
-        verify(rightPanel, times(1)).resetFilter();
 
         // Verify the predicate passed to updateFilteredTransactionList
         verify(mockCommonModel, times(1)).updateFilteredTransactionList(argThat(predicate -> {
@@ -101,15 +99,13 @@ public class RightPanelTest {
     }
 
     @Test
-    public void testShowAllDoneOrNotDoneTransactions_callsResetFilterAndUpdatesPredicate()
+    public void testShowAllDoneOrNotDoneTransactions_updatesPredicate()
             throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
         // Call the private method "filterTransactionsByDoneStatus" using reflection
         Method showAllDoneOrNotDoneTransactions = RightPanel.class.getDeclaredMethod(
                 "showAllDoneOrNotDoneTransactions");
         showAllDoneOrNotDoneTransactions.setAccessible(true);
         showAllDoneOrNotDoneTransactions.invoke(rightPanel);
-
-        verify(rightPanel, times(1)).resetFilter();
 
         // Verify the predicate passed to updateFilteredTransactionList
         verify(mockCommonModel, times(1)).updateFilteredTransactionList(argThat(predicate -> {


### PR DESCRIPTION
### What this PR do
**The problem**: When a user clicks "Filter by done or undone status" > then "Reset Filter" > then "Filter by done or undone status" again. The txn pane shows all undone transaction, indicating that reset filter does not reset toggle information.
**What we want**: The txn pane shows all done transaction, just like the first time u click "Filter by done or undone status".

- reset filter method to reset toggle information
- refactor method naming for clarity
- update menu item naming for clarity
- make GUI testing faster by waiting human delay at 10 milliseconds

closes #320