### PR TITLE
 Add wrap text to amount field

### DIFF
--- a/src/main/resources/view/RightPanel.fxml
+++ b/src/main/resources/view/RightPanel.fxml
@@ -9,18 +9,18 @@
 <?import javafx.scene.layout.VBox?>
 <?import javafx.scene.control.CheckBox?>
 <AnchorPane xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1" fx:id="rightPanel">
-    <VBox spacing="15" AnchorPane.topAnchor="0" AnchorPane.leftAnchor="0" AnchorPane.rightAnchor="0" AnchorPane.bottomAnchor="0" minWidth="350">
+    <VBox spacing="15" AnchorPane.topAnchor="0" AnchorPane.leftAnchor="0" AnchorPane.rightAnchor="0" AnchorPane.bottomAnchor="0" minWidth="400">
         <Label text="Transactions" styleClass="title"/>
 
         <HBox spacing="10" styleClass="total-balance">
             <VBox alignment="CENTER_LEFT" spacing="5">
-                <Label fx:id="youOweLabel" styleClass="label, you-owe-text"/>
-                <Label fx:id="youAreOwedLabel" styleClass="label, you-are-owed-text"/>
+                <Label fx:id="youOweLabel" styleClass="label, you-owe-text" wrapText="true"/>
+                <Label fx:id="youAreOwedLabel" styleClass="label, you-are-owed-text" wrapText="true"/>
             </VBox>
             <Region HBox.hgrow="ALWAYS"/>
             <VBox alignment="CENTER_RIGHT" spacing="5">
                 <Button fx:id="filterBtn" styleClass="filter-btn"/>
-                <CheckBox fx:id="trackUndoneBalanceOnlyCheckBox" text="Track undone balance only" styleClass="label"/>
+                <CheckBox fx:id="trackUndoneBalanceOnlyCheckBox" text="Track undone balance only" styleClass="label" wrapText="true"/>
             </VBox>
         </HBox>
 

--- a/src/main/resources/view/TransactionListCard.fxml
+++ b/src/main/resources/view/TransactionListCard.fxml
@@ -36,7 +36,7 @@
 
         <VBox alignment="CENTER_RIGHT" spacing="10" minWidth="70" maxWidth="70" GridPane.columnIndex="2">
             <Label fx:id="status" styleClass="amount"/>
-            <Label fx:id="amount" styleClass="amount"/>
+            <Label fx:id="amount" styleClass="amount" wrapText="true"/>
         </VBox>
     </GridPane>
 </HBox>


### PR DESCRIPTION
### What this PR do
The problem: If amount gets too big, the amount text will get truncated.
The fix: Add wrap text to the label.

closes #346 