### PR TITLE
Update invalid index error message for clarity

### DIFF
--- a/src/main/java/spleetwaise/address/logic/Messages.java
+++ b/src/main/java/spleetwaise/address/logic/Messages.java
@@ -14,7 +14,7 @@ public class Messages {
 
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
-    public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
+    public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "No such person at index %d";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =
             "Multiple values specified for the following single-valued field(s): ";

--- a/src/main/java/spleetwaise/commons/logic/commands/CommandUtil.java
+++ b/src/main/java/spleetwaise/commons/logic/commands/CommandUtil.java
@@ -30,7 +30,8 @@ public class CommandUtil {
         List<Person> lastShownList = model.getFilteredPersonList();
 
         if (index.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+            throw new CommandException(
+                    String.format(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX, index.getOneBased()));
         }
 
         return lastShownList.get(index.getZeroBased());

--- a/src/main/java/spleetwaise/transaction/logic/parser/ParserUtil.java
+++ b/src/main/java/spleetwaise/transaction/logic/parser/ParserUtil.java
@@ -140,7 +140,8 @@ public class ParserUtil extends BaseParserUtil {
         List<Person> lastShownList = CommonModelManager.getInstance().getFilteredPersonList();
 
         if (index.getZeroBased() >= lastShownList.size()) {
-            throw new ParseException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+            throw new ParseException(
+                    String.format(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX, index.getOneBased()));
         }
 
         return lastShownList.get(index.getZeroBased());

--- a/src/test/java/spleetwaise/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/spleetwaise/address/logic/commands/DeleteCommandTest.java
@@ -64,7 +64,9 @@ public class DeleteCommandTest {
         DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
 
         CommandTestUtil.assertCommandFailure(
-                deleteCommand, addressBookModel, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+                deleteCommand, addressBookModel,
+                String.format(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX, outOfBoundIndex.getOneBased())
+        );
     }
 
     @Test
@@ -113,7 +115,9 @@ public class DeleteCommandTest {
         DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
 
         CommandTestUtil.assertCommandFailure(
-                deleteCommand, addressBookModel, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+                deleteCommand, addressBookModel,
+                String.format(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX, outOfBoundIndex.getOneBased())
+        );
     }
 
     @Test

--- a/src/test/java/spleetwaise/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/spleetwaise/address/logic/commands/EditCommandTest.java
@@ -138,7 +138,10 @@ public class EditCommandTest {
                 new EditPersonDescriptorBuilder().withName(CommandTestUtil.VALID_NAME_BOB).build();
         EditCommand editCommand = new EditCommand(outOfBoundIndex, descriptor);
 
-        CommandTestUtil.assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        CommandTestUtil.assertCommandFailure(
+                editCommand, model,
+                String.format(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX, outOfBoundIndex.getOneBased())
+        );
     }
 
     /**
@@ -156,7 +159,11 @@ public class EditCommandTest {
                 new EditPersonDescriptorBuilder().withName(CommandTestUtil.VALID_NAME_BOB).build()
         );
 
-        CommandTestUtil.assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        CommandTestUtil.assertCommandFailure(
+                editCommand, model, String.format(
+                        Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX,
+                        outOfBoundIndex.getOneBased()
+                ));
     }
 
     @Test

--- a/src/test/java/spleetwaise/commons/logic/LogicManagerTest.java
+++ b/src/test/java/spleetwaise/commons/logic/LogicManagerTest.java
@@ -90,7 +90,7 @@ public class LogicManagerTest {
     @Test
     public void execute_commandExecutionError_throwsCommandException() {
         String deleteCommand = "delete 9";
-        assertCommandException(deleteCommand, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        assertCommandException(deleteCommand, String.format(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX, 9));
     }
 
     @Test

--- a/src/test/java/spleetwaise/commons/logic/commands/CommandUtilTest.java
+++ b/src/test/java/spleetwaise/commons/logic/commands/CommandUtilTest.java
@@ -78,7 +78,13 @@ public class CommandUtilTest {
         );
 
         // Verify the exception message
-        assertEquals(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX, exception.getMessage());
+        assertEquals(
+                String.format(
+                        Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX,
+                        outOfBoundsIndex.getOneBased()
+                ),
+                exception.getMessage()
+        );
     }
 
     @Test
@@ -93,6 +99,9 @@ public class CommandUtilTest {
         );
 
         // Verify the exception message
-        assertEquals(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX, exception.getMessage());
+        assertEquals(
+                String.format(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX, INDEX_FIRST_PERSON.getOneBased()),
+                exception.getMessage()
+        );
     }
 }

--- a/src/test/java/spleetwaise/transaction/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/spleetwaise/transaction/logic/parser/AddCommandParserTest.java
@@ -81,7 +81,10 @@ public class AddCommandParserTest {
         assertParseFailure(parser, userInput, MESSAGE_INVALID_FORMAT);
 
         userInput = " " + (abModel.getFilteredPersonList().size() + 1) + " amt/1.23 desc/description date/01012024";
-        assertParseFailure(parser, userInput, MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        assertParseFailure(
+                parser, userInput,
+                String.format(MESSAGE_INVALID_PERSON_DISPLAYED_INDEX, abModel.getFilteredPersonList().size() + 1)
+        );
     }
 
     @Test

--- a/src/test/java/spleetwaise/transaction/logic/parser/FilterCommandParserTest.java
+++ b/src/test/java/spleetwaise/transaction/logic/parser/FilterCommandParserTest.java
@@ -166,8 +166,13 @@ public class FilterCommandParserTest {
         userInput = " invalid";
         assertParseFailure(parser, userInput, ParserUtil.MESSAGE_INVALID_INDEX);
 
-        userInput = " " + abModel.getFilteredPersonList().size() + 1;
-        assertParseFailure(parser, userInput, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        Integer outOfBoundsIndexInt = abModel.getFilteredPersonList().size() + 1;
+        userInput = " " + outOfBoundsIndexInt;
+        assertParseFailure(
+                parser, userInput, String.format(
+                        Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX,
+                        outOfBoundsIndexInt
+                ));
     }
 
     @Test


### PR DESCRIPTION
Closes #371 

Makes error message clearer for cases:

- Index is valid, but does not point to a valid person
- Index is invalid