### PR TITLE
Fix empty amount json nullptr exception

### DIFF
--- a/src/main/java/spleetwaise/transaction/model/transaction/Amount.java
+++ b/src/main/java/spleetwaise/transaction/model/transaction/Amount.java
@@ -45,6 +45,7 @@ public class Amount {
      * @return Returns true if the test string passes the regex check and is non-zero value
      */
     public static boolean isValidAmount(String test) {
+        requireNonNull(test);
         return test.trim().matches(VALIDATION_REGEX) && new BigDecimal(test.trim()).compareTo(BigDecimal.ZERO) != 0;
     }
 

--- a/src/main/java/spleetwaise/transaction/storage/adapters/JsonAdaptedAmount.java
+++ b/src/main/java/spleetwaise/transaction/storage/adapters/JsonAdaptedAmount.java
@@ -47,7 +47,7 @@ public class JsonAdaptedAmount {
      * @throws IllegalValueException if the string is not a valid amount
      */
     public Amount toModelType() throws IllegalValueException {
-        if (!Amount.isValidAmount(amount)) {
+        if (amount == null || !Amount.isValidAmount(amount)) {
             throw new IllegalValueException(Amount.MESSAGE_CONSTRAINTS);
         }
         return new Amount(amount);

--- a/src/test/java/spleetwaise/transaction/storage/adapters/JsonAdaptedAmountTest.java
+++ b/src/test/java/spleetwaise/transaction/storage/adapters/JsonAdaptedAmountTest.java
@@ -34,6 +34,12 @@ public class JsonAdaptedAmountTest {
     }
 
     @Test
+    public void testConstructor_string_null() {
+        // Test creating an instance with a null string
+        assertThrows(IllegalValueException.class, () -> (new JsonAdaptedAmount((String) null)).toModelType());
+    }
+
+    @Test
     public void testConstructor_amount_positiveAmount() {
         // Create an Amount object
         Amount amount = new Amount(VALID_AMOUNT_POSITIVE);


### PR DESCRIPTION
Closes #363 
* adds a null-check condition to `JsonAdaptedAmount.toModelType` to guard against this scenario.
* adds an explicit `requireNonNull` to the original culprit method to ensure we catch all future null pointer exceptions.
* updates `JsonAdaptedAmountTest` with this scenario.

The program now discards corrupted transactions as expected.