### PR TITLE
Remove phone param for `editTxn`

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -185,7 +185,7 @@ Examples:
 
 Edits an existing transaction in the transaction book.
 
-Format: `editTxn INDEX [p/PHONE_NUMBER] [amt/AMOUNT] [desc/DESCRIPTION] [date/DATE] [cat/CATEGORY]...`
+Format: `editTxn INDEX [amt/AMOUNT] [desc/DESCRIPTION] [date/DATE] [cat/CATEGORY]...`
 
 * Edits the transaction at the specified `INDEX`. The index refers to the index number shown in the displayed transaction list.
   The index **must be a positive integer** 1, 2, 3, …
@@ -194,13 +194,12 @@ Format: `editTxn INDEX [p/PHONE_NUMBER] [amt/AMOUNT] [desc/DESCRIPTION] [date/DA
 * When editing categories, the existing categories of the transaction will be removed i.e adding of categories is not
   cumulative.
 * You can remove all the person’s categories by typing `cat/` without specifying any categories after it.
-* When editing the person related to the transaction through specifying `[p/PHONE_NUMBER]`, the person with the input phone number must be in the address book.
 
 :bulb: **Tip:** Status can be edited via `markDone` or `markUndone` command. Support for editing status through `editTxn` may be considered by the devs in future releases.
 
 Examples:
 
-* `editTxn 1 p/92624417 desc/Hello world` Edits the 1st transaction to be related to the person with phone number `92624417` and edits the description of the 1st transaction to be `Hello world` (ensure that the phone number is valid, i.e. it exists in the address book).
+* `editTxn 1 desc/Hello world` edits the description of the 1st transaction to be `Hello world`.
 * `editTxn 2 cat/` Edits the 2nd transaction by removing all existing categories.
 
 ### Locating persons by name: `find`
@@ -401,12 +400,12 @@ _Details coming soon ..._
 
 ## Command Summary for Transactions
 
-| Action          | Format, Examples                                                                                                                                                                                                             |
-|-----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **Add**         | `addTxn INDEX amt/AMOUNT desc/DESCRIPTION [date/DATE] [status/STATUS] [cat/CATEGORY]` <br> e.g., `addTxn 1 amt/9999999999.99 desc/Sean owes me a lot for a plot of land in sentosa date/10102024 status/Done cat/LOAN`       |
-| **Edit**        | `editTxn INDEX [p/PHONE_NUMBER] [amt/AMOUNT] [desc/DESCRIPTION] [date/DATE] [cat/CATEGORY]` <br> e.g., `editTxn 1 p/99999999 amt/9999999999.99 desc/Sean owes me a lot for a plot of land in sentosa date/10102024 cat/LOAN` |
-| **List**        | `listTxn`                                                                                                                                                                                                                    |
-| **Filter**      | `filterTxn [INDEX] [amt/AMOUNT] [desc/DESCRIPTION] [date/DATE] [status/STATUS] [amtsign/AMOUNT_SIGN]` <br> e.g. `filterTxn 1`                                                                                                |
-| **Clear**       | `clearTxn`                                                                                                                                                                                                                   |
-| **Mark Done**   | `markDone INDEX` <br> e.g. `markDone 1`                                                                                                                                                                                      |
-| **Mark Undone** | `markUndone INDEX` <br> e.g. `markUndone 1`                                                                                                                                                                                  |
+| Action          | Format, Examples                                                                                                                                                                                                       |
+|-----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Add**         | `addTxn INDEX amt/AMOUNT desc/DESCRIPTION [date/DATE] [status/STATUS] [cat/CATEGORY]` <br> e.g., `addTxn 1 amt/9999999999.99 desc/Sean owes me a lot for a plot of land in sentosa date/10102024 status/Done cat/LOAN` |
+| **Edit**        | `editTxn INDEX [amt/AMOUNT] [desc/DESCRIPTION] [date/DATE] [cat/CATEGORY]` <br> e.g., `editTxn 1 amt/9999999999.99 desc/Sean owes me a lot for a plot of land in sentosa date/10102024 cat/LOAN`                       |
+| **List**        | `listTxn`                                                                                                                                                                                                              |
+| **Filter**      | `filterTxn [INDEX] [amt/AMOUNT] [desc/DESCRIPTION] [date/DATE] [status/STATUS] [amtsign/AMOUNT_SIGN]` <br> e.g. `filterTxn 1`                                                                                          |
+| **Clear**       | `clearTxn`                                                                                                                                                                                                             |
+| **Mark Done**   | `markDone INDEX` <br> e.g. `markDone 1`                                                                                                                                                                                |
+| **Mark Undone** | `markUndone INDEX` <br> e.g. `markUndone 1`                                                                                                                                                                            |

--- a/src/main/java/spleetwaise/transaction/logic/commands/EditCommand.java
+++ b/src/main/java/spleetwaise/transaction/logic/commands/EditCommand.java
@@ -43,7 +43,7 @@ public class EditCommand extends Command {
     public static final String MESSAGE_USAGE =
             COMMAND_WORD + ": Edit a transaction.\n"
                     + "Parameters: INDEX (must be a positive integer) "
-                    + "[" + PREFIX_PHONE + "CONTACT] "
+                    //+ "[" + PREFIX_PHONE + "CONTACT] "
                     + "[" + PREFIX_AMOUNT + "AMOUNT] "
                     + "[" + PREFIX_DESCRIPTION + "DESCRIPTION] "
                     + "[" + PREFIX_DATE + "DATE] "

--- a/src/main/java/spleetwaise/transaction/logic/parser/EditCommandParser.java
+++ b/src/main/java/spleetwaise/transaction/logic/parser/EditCommandParser.java
@@ -1,8 +1,6 @@
 package spleetwaise.transaction.logic.parser;
 
 import static spleetwaise.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static spleetwaise.address.logic.parser.CliSyntax.PREFIX_PHONE;
-import static spleetwaise.address.logic.parser.ParserUtil.parsePhone;
 import static spleetwaise.transaction.logic.commands.EditCommand.MESSAGE_USAGE;
 import static spleetwaise.transaction.logic.parser.CliSyntax.PREFIX_AMOUNT;
 import static spleetwaise.transaction.logic.parser.CliSyntax.PREFIX_CATEGORY;
@@ -16,7 +14,6 @@ import java.util.Set;
 
 import spleetwaise.address.logic.parser.ArgumentMultimap;
 import spleetwaise.address.logic.parser.ArgumentTokenizer;
-import spleetwaise.address.model.person.Phone;
 import spleetwaise.commons.core.index.Index;
 import spleetwaise.commons.logic.parser.Parser;
 import spleetwaise.commons.logic.parser.exceptions.ParseException;
@@ -36,7 +33,13 @@ public class EditCommandParser implements Parser<EditCommand> {
     public EditCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(
-                        args, PREFIX_PHONE, PREFIX_AMOUNT, PREFIX_DESCRIPTION, PREFIX_DATE, PREFIX_CATEGORY);
+                        args,
+                        //PREFIX_PHONE,
+                        PREFIX_AMOUNT,
+                        PREFIX_DESCRIPTION,
+                        PREFIX_DATE,
+                        PREFIX_CATEGORY
+                );
 
         // Parse index
         Index index;
@@ -48,14 +51,18 @@ public class EditCommandParser implements Parser<EditCommand> {
 
         // Parse descriptors
         argMultimap.verifyNoDuplicatePrefixesFor(
-                PREFIX_PHONE, PREFIX_AMOUNT, PREFIX_DESCRIPTION, PREFIX_DATE);
+                //PREFIX_PHONE,
+                PREFIX_AMOUNT,
+                PREFIX_DESCRIPTION,
+                PREFIX_DATE
+        );
 
         EditTransactionDescriptor editTransactionDescriptor = new EditTransactionDescriptor();
 
-        if (argMultimap.getValue(PREFIX_PHONE).isPresent()) {
-            Phone phone = parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
-            editTransactionDescriptor.setPerson(ParserUtil.getPersonFromPhone(phone));
-        }
+        //if (argMultimap.getValue(PREFIX_PHONE).isPresent()) {
+        //  Phone phone = parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
+        //  editTransactionDescriptor.setPerson(ParserUtil.getPersonFromPhone(phone));
+        //}
 
         if (argMultimap.getValue(PREFIX_AMOUNT).isPresent()) {
             Amount amount = ParserUtil.parseAmount(argMultimap.getValue(PREFIX_AMOUNT).get());

--- a/src/test/java/spleetwaise/transaction/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/spleetwaise/transaction/logic/parser/EditCommandParserTest.java
@@ -1,6 +1,5 @@
 package spleetwaise.transaction.logic.parser;
 
-import static spleetwaise.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static spleetwaise.commons.testutil.Assert.assertThrows;
 import static spleetwaise.transaction.logic.parser.CliSyntax.PREFIX_AMOUNT;
 import static spleetwaise.transaction.logic.parser.CliSyntax.PREFIX_CATEGORY;
@@ -15,7 +14,6 @@ import org.junit.jupiter.api.Test;
 
 import spleetwaise.address.model.AddressBookModel;
 import spleetwaise.address.model.AddressBookModelManager;
-import spleetwaise.address.model.person.Phone;
 import spleetwaise.address.testutil.TypicalPersons;
 import spleetwaise.commons.core.index.Index;
 import spleetwaise.commons.logic.parser.exceptions.ParseException;
@@ -72,10 +70,6 @@ public class EditCommandParserTest {
     public void parse_invalidValue_failure() {
         // single invalid fields
         CommandParserTestUtil.assertParseFailure(
-                parser, "1 " + PREFIX_PHONE + "notAPhoneNumber", Phone.MESSAGE_CONSTRAINTS);
-        CommandParserTestUtil.assertParseFailure(
-                parser, "1 " + PREFIX_PHONE + "12345678", ParserUtil.MESSAGE_PHONE_NUMBER_IS_UNKNOWN);
-        CommandParserTestUtil.assertParseFailure(
                 parser, "1 " + PREFIX_AMOUNT + "notAnAmount", Amount.MESSAGE_CONSTRAINTS);
         CommandParserTestUtil.assertParseFailure(
                 parser, "1 " + PREFIX_DESCRIPTION + "", Description.MESSAGE_CONSTRAINTS);
@@ -91,7 +85,6 @@ public class EditCommandParserTest {
     @Test
     public void parse_allFieldsSpecified_success() {
         EditCommand.EditTransactionDescriptor descriptor = new EditCommand.EditTransactionDescriptor();
-        descriptor.setPerson(TypicalPersons.ALICE);
         descriptor.setAmount(new Amount("100"));
         descriptor.setDescription(new Description("hello"));
         descriptor.setDate(new Date("01012024"));
@@ -99,10 +92,8 @@ public class EditCommandParserTest {
         EditCommand expectedCommand = new EditCommand(Index.fromOneBased(1), descriptor);
 
         CommandParserTestUtil.assertParseSuccess(
-                parser, String.format(
-                        "1 p/%s amt/100 desc/hello date/01012024 cat/TEST",
-                        TypicalPersons.ALICE.getPhone().toString()
-                ),
+                parser,
+                "1 amt/100 desc/hello date/01012024 cat/TEST",
                 expectedCommand
         );
     }
@@ -110,15 +101,12 @@ public class EditCommandParserTest {
     @Test
     public void parse_someFieldsSpecified_success() {
         EditCommand.EditTransactionDescriptor descriptor = new EditCommand.EditTransactionDescriptor();
-        descriptor.setPerson(TypicalPersons.ALICE);
         descriptor.setDescription(new Description("hello"));
         EditCommand expectedCommand = new EditCommand(Index.fromOneBased(1), descriptor);
 
         CommandParserTestUtil.assertParseSuccess(
-                parser, String.format(
-                        "1 p/%s desc/hello",
-                        TypicalPersons.ALICE.getPhone().toString()
-                ),
+                parser,
+                "1 desc/hello",
                 expectedCommand
         );
     }

--- a/src/test/java/spleetwaise/transaction/logic/parser/TransactionBookParserTest.java
+++ b/src/test/java/spleetwaise/transaction/logic/parser/TransactionBookParserTest.java
@@ -69,8 +69,7 @@ public class TransactionBookParserTest {
 
     @Test
     public void parseCommand_editTxnCommand() throws ParseException {
-        EditCommand command = (EditCommand) parser.parseCommand(
-                String.format("editTxn 1 p/%s", TypicalPersons.ALICE.getPhone()));
+        EditCommand command = (EditCommand) parser.parseCommand("editTxn 1 amt/10");
         assertNotNull(command);
     }
 }


### PR DESCRIPTION
Closes #446 by softly removing parsing for phone number in the `editTxn` command.