### PR TITLE
id clarification for editing data files

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -5,7 +5,9 @@ title: User Guide
 
 SpleetWaise builds on [AddressBook Level 3 (AB3)](https://se-education.org/addressbook-level3/) – **a desktop app for managing contacts, optimized for use via a Command Line Interface** (CLI) while still offering the benefits of a Graphical User Interface (GUI). SpleetWaise makes it easy for students to record transactions with contacts saved in the address book. If you can type fast, SpleetWaise lets you handle your contact and transaction management tasks more efficiently than traditional GUI apps.
 
-:exclamation: **Disclaimer:** Our app currently focuses on supporting university students based in Singapore and the English language only. The app may not be suitable for other non-university students and are not based in Singapore or users who prefer other languages. If users choose to use the app outside of these parameters, it may behave unexpectedly or not as intended.
+<div markdown="span" class="alert alert-info">
+**Disclaimer:** Our app currently focuses on supporting _university students_ based in _Singapore_ and the _English language_ only. The app may not be suitable for other non-university students and are not based in Singapore or users who prefer other languages. If users choose to use the app outside of these parameters, it may behave unexpectedly or not as intended.
+</div>
 
 * Table of Contents
 {:toc}
@@ -376,13 +378,18 @@ AddressBook and Transaction data are saved in the hard disk automatically after 
 - TransactionBook data are saved automatically as a JSON file `[JAR file location]/data/transactionbook.json` 
 - Advanced users are welcome to update data directly by editing that data file.
 
-<div markdown="span" class="alert alert-warning">:exclamation: **Caution:**
-If changes to the data file make its format invalid, SpleetWaise will discard corrupted data and start as usual. To avoid data loss, it’s recommended to back up the file before making edits. Person and Transactions with invalid fields will be discarded before the application starts.<br>
-Furthermore, certain edits can cause the AddressBook or TransactionBook to behave in unexpected ways (e.g., if a value entered is outside the acceptable range). Therefore, edit the data file only if you are confident that you can update it correctly.
-Notably, if SpleetWaise encounter a person/transaction with an existing person/transaction ID in the 
-address/transaction book, it will be discarded. Similarly, if SpleetWaise encounter a transaction with the same 
-person ID, amount, date and description as an existing transaction in the transaction book, it will be discarded as 
-well.
+<div markdown="block" class="alert alert-warning" style="text-align: justify;">:exclamation: **Caution:**
+If changes to the data files make its format invalid, SpleetWaise will discard corrupted data and start as usual. To avoid data loss, it’s recommended to back up the file before making edits. Person and Transactions with invalid fields will be discarded before the application starts.<br>
+
+Furthermore, certain edits can cause the app to behave in unexpected ways (e.g., if a value entered is outside the acceptable range). Therefore, edit the data files only if you are confident that you can update it correctly.
+</div>
+
+<div markdown="block" class="alert alert-danger" style="text-align: justify;">:exclamation: **Important**: 
+In addition to the stated criteria for duplicates, when editing through the data files, if a new person or transaction entry has the same `id` as an existing person or transaction in the addressbook.json or transactionbook.json respectively, it will be discarded. Additionally, the `personId` in transactions.json must match the `id` of a person in addressbook.json.
+
+If you must edit existing entries' `id` or create new entries through the data files, please ensure their `id` fields follow the [UUID](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/UUID.html) format (Users may explore using [UUID generators](https://www.uuidgenerator.net/version7) to create unique `id` values for new entries). Failing to follow this guideline may cause the app to behave in unexpected ways.
+
+The `id` field in both persons and transactions is essential for maintaining [referential integrity](https://intelligent-ds.com/blog/what-is-referential-integrity) within the address and transaction books, are intended for internal reference. These `id` link transactions to their respective persons and vice versa.
 </div>
 
 ### Archiving data files `[coming in v2.0]`

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -389,7 +389,7 @@ In addition to the stated criteria for duplicates, when editing through the data
 
 If you must edit existing entries' `id` or create new entries through the data files, please ensure their `id` fields follow the [UUID](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/UUID.html) format (Users may explore using [UUID generators](https://www.uuidgenerator.net/version7) to create unique `id` values for new entries). Failing to follow this guideline may cause the app to behave in unexpected ways.
 
-The `id` field in both persons and transactions is essential for maintaining [referential integrity](https://intelligent-ds.com/blog/what-is-referential-integrity) within the address and transaction books, are intended for internal reference. These `id` link transactions to their respective persons and vice versa.
+The `id` field in both persons and transactions is essential for maintaining [referential integrity](https://www.sciencedirect.com/topics/computer-science/referential-integrity) within the address and transaction books, and are intended for internal reference as the devs aim to mimic databases' with referential integrity to ensure valid relationships between persons and transactions. These `id` link transactions to their respective persons and vice versa.
 </div>
 
 ### Archiving data files `[coming in v2.0]`


### PR DESCRIPTION
### Summary
This pull request addresses resolves #473 by clarifying the handling of IDs when editing data files in the SpleetWaise application. The updates are made to the User Guide documentation to provide clearer instructions and warnings regarding data file modifications.

<img width="786" alt="Screenshot 2024-11-10 at 1 55 28 PM" src="https://github.com/user-attachments/assets/c1cf473f-d854-4f9c-8329-f928cd1f2188">

### Key Changes
- Enhanced the disclaimer section to improve readability.
- Added detailed caution and important notes about editing data files, focusing on the handling of `id` fields.
- Introduced guidelines for using UUIDs to maintain referential integrity within data files.

### Additional Information
- The `id` field is crucial for linking transactions to their respective persons.
- Users are advised to back up data files before making any manual edits to prevent data loss.
- The changes aim to prevent unexpected behavior by ensuring data integrity when users manually edit JSON files.

Related to #374