### PR TITLE
Remove track only undone balance feature

### DIFF
--- a/src/main/resources/view/RightPanel.fxml
+++ b/src/main/resources/view/RightPanel.fxml
@@ -7,7 +7,6 @@
 <?import javafx.scene.layout.Region?>
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
-<?import javafx.scene.control.CheckBox?>
 <AnchorPane xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1" fx:id="rightPanel">
     <VBox spacing="15" AnchorPane.topAnchor="0" AnchorPane.leftAnchor="0" AnchorPane.rightAnchor="0" AnchorPane.bottomAnchor="0" minWidth="400">
         <Label text="Transactions" styleClass="title"/>
@@ -20,7 +19,6 @@
             <Region HBox.hgrow="ALWAYS"/>
             <VBox alignment="CENTER_RIGHT" spacing="5">
                 <Button fx:id="filterBtn" styleClass="filter-btn"/>
-                <CheckBox fx:id="trackUndoneBalanceOnlyCheckBox" text="Track undone balance only" styleClass="label" wrapText="true"/>
             </VBox>
         </HBox>
 


### PR DESCRIPTION
### The problem
The feature "Track undone balance only" requires users to click on the checkbox, which is not align with the TP constraint of "Typing Preferred", as there is no equivalent typing command for this, and hence a bug.

### Changes
- Remove track only undone balance feature. Removing this feature has little impact as user can still filter transaction with undone status.

closes #406, closes #427, closes #389 