### PR TITLE
Standardize "undone" as "Not Done"

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -297,4 +297,4 @@ You can navigate the gradle terminal by clicking on elephant icon _(Gradle)_ > t
 
    3. Test cases: Missing `isDone` field in `transactionbook.json` data file<br>
       Simulation: Remove the `isDone` field from a transaction entry in the JSON file, then start the app.<br>
-      Expected: The transaction loads as undone by default. Upon closing the app, the transaction is saved as undone in the JSON file.
+      Expected: The transaction loads as not done by default. Upon closing the app, the transaction is saved as not done in the JSON file.

--- a/docs/_includes/DeveloperGuide/Requirements/02_use_cases.md
+++ b/docs/_includes/DeveloperGuide/Requirements/02_use_cases.md
@@ -71,12 +71,12 @@ Actor: New User
 
 ---
 
-**UC05 - Mark and Unmark Expenses**
+**UC05 - Mark Expenses as Done or Not Done**
 
 **MSS**
 1. A user requests to list expenses
 2. The system shows a list of expenses
-3. The user requests to mark or unmark the selected expense.
+3. The user requests to mark the selected expense as Done or Not Done.
 4. The system updates the status of the expense.
 5. The system displays a success message indicating the change.
    <br>Use case ends.<br>

--- a/docs/_includes/DeveloperGuide/Requirements/04_glossary.md
+++ b/docs/_includes/DeveloperGuide/Requirements/04_glossary.md
@@ -4,5 +4,5 @@ This Spleetwaise app is a _single-user_ application. Transactions are relative t
 - **Mainstream OS**: Windows, Linux, Unix, macOS
 - **Private contact detail**: A contact detail that is not meant to be shared with others
 - **Transaction**: A Transaction represents a record of a financial interaction between <ins>_the user_</ins> and another party (another contact).
-  - **Undone** Transaction: By default, a newly created transaction is set as undone - _e.g._ if the transaction is added as `addTxn 1 amt/12.3 desc/John owes me for dinner`, this transaction is not done, John still owes <ins>_the user_</ins>.
+  - **Not Done** Transaction: By default, a newly created transaction is set as not done - _e.g._ if the transaction is added as `addTxn 1 amt/12.3 desc/John owes me for dinner`, this transaction is not done, John still owes <ins>_the user_</ins>.
   - **Done** Transaction: A completed transaction, referring to the previous _e.g._ once John has paid <ins>_the user_</ins>, he will mark the transaction as done.


### PR DESCRIPTION
### The problem
"Undone" and "Not Done" are used interchangeable, and Glossary section includes only "Undone" definition.

### What this PR do
Standardize to use "Not Done" instead.

---
closes #441 