### PR TITLE
Update Amount Validation regex

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -123,7 +123,6 @@ Format: `addTxn INDEX amt/AMOUNT desc/DESCRIPTION [date/DATE] [status/STATUS] [c
 
 * The `INDEX` refers to the index of the person currently displayed in the address book panel (as we are adding the transaction related to the person).
 * The `AMOUNT` accepts a decimal number with up to 2 decimal places. A `-` symbol should be added before the number to indicate negative amount, indicating the transaction is one that the user owes the chosen person at the index.
-  * Amount with an absolute value less than 1 dollar should have a leading 0.
   * Positive Amount Transaction indicates someone owes the user an amount.<br>
     e.g. `addTxn 1 amt/12.30 desc/John owes me for dinner` indicates that John owes the user S$12.30.
   * Negative Amount Transaction indicates the user owes someone an amount.<br>
@@ -264,7 +263,6 @@ Format: `filterTxn [INDEX] [amt/AMOUNT] [desc/DESCRIPTION] [date/DATE] [status/S
 * The `INDEX` refers to the index number shown in the displayed person list.
   The index **must be a positive integer** 1, 2, 3, …​
 * The `AMOUNT` accepts a decimal number with up to 2 decimal places. A `-` symbol should be added before the number to indicate negative amount, indicating the transaction is one that the user owes the chosen person at the index. Results will display transactions with the exact amount if it exists.
-  * Amount with an absolute value less than 1 dollar should have a leading 0.
   * Amount with value equivalent of 0 is not allowed and will be considered as invalid input as transaction with 0
     amount does not make sense and would be considered as spam.
 * The `DATE` accepts date formatted in the form `DDMMYYYY` i.e.`10102024`.

--- a/src/main/java/spleetwaise/transaction/model/transaction/Amount.java
+++ b/src/main/java/spleetwaise/transaction/model/transaction/Amount.java
@@ -20,7 +20,7 @@ public class Amount {
     /*
      * The first character of amount must be + or - and only allow precision up to 2 decimal places
      */
-    public static final String VALIDATION_REGEX = "^(\\-)?([\\d]+$|[\\d]+\\.[\\d]{1,2}$)";
+    public static final String VALIDATION_REGEX = "^(\\-)?([\\d]+$|[\\d]*\\.[\\d]{1,2}$)";
 
     private static final int MAX_DECIMAL_PLACES = 2;
 

--- a/src/test/java/spleetwaise/transaction/model/transaction/AmountTest.java
+++ b/src/test/java/spleetwaise/transaction/model/transaction/AmountTest.java
@@ -66,6 +66,10 @@ public class AmountTest {
         assertTrue(Amount.isValidAmount("-0.01"));
         assertTrue(Amount.isValidAmount("0.1"));
         assertTrue(Amount.isValidAmount("-0.1"));
+        assertTrue(Amount.isValidAmount(".01"));
+        assertTrue(Amount.isValidAmount("-.01"));
+        assertTrue(Amount.isValidAmount(".1"));
+        assertTrue(Amount.isValidAmount("-.1"));
     }
 
     @Test
@@ -85,6 +89,10 @@ public class AmountTest {
 
         amt1 = new Amount("100");
         assertTrue(amt1.equals(amt1));
+
+        Amount amt3 = new Amount("-0.01");
+        Amount amt4 = new Amount("-.01");
+        assertTrue(amt3.equals(amt4));
     }
 
     @Test


### PR DESCRIPTION
Fixes #409 
Referencing from the textbook:
![telegram-cloud-photo-size-5-6161253194999644480-y](https://github.com/user-attachments/assets/f44db620-ddcc-423f-a124-63a7412ad3a1)

With approval from prof
<img width="955" alt="Screenshot 2024-11-10 at 10 42 26 PM" src="https://github.com/user-attachments/assets/c17c112d-49ce-4354-b546-efb11c615d30">

We fix the bug with Amount where it deemed `-.01`, where the amount is less than a dollar is specified, to be rejected